### PR TITLE
[feat] 집안일 추가 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/homemate/chores/controller/ChoresController.java
+++ b/src/main/java/com/zerobase/homemate/chores/controller/ChoresController.java
@@ -1,0 +1,30 @@
+package com.zerobase.homemate.chores.controller;
+
+import com.zerobase.homemate.chores.dto.ChoresDto;
+import com.zerobase.homemate.chores.service.ChoresService;
+import com.zerobase.homemate.util.JwtUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/chores")
+@RequiredArgsConstructor
+public class ChoresController {
+
+    private final ChoresService choresService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/create")
+    public ResponseEntity<ChoresDto.Response> createChores(
+            @RequestHeader("Authorization") String authorization,
+            @Valid @RequestBody ChoresDto.CreateRequest request) {
+
+        Long userId = jwtUtil.extractUserIdFromToken(authorization);
+        ChoresDto.Response response = choresService.createChores(userId, request);
+        
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/zerobase/homemate/chores/dto/ChoresDto.java
+++ b/src/main/java/com/zerobase/homemate/chores/dto/ChoresDto.java
@@ -3,6 +3,7 @@ package com.zerobase.homemate.chores.dto;
 import com.zerobase.homemate.entity.Chores;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,7 +27,7 @@ public class ChoresDto {
         @NotNull(message = "알림 여부는 필수입니다")
         private Boolean notificationYn;
 
-        private String notificationTime;
+        private LocalTime notificationTime;
 
         private String space;
 
@@ -51,7 +52,7 @@ public class ChoresDto {
         private Long id;
         private String title;
         private Boolean notificationYn;
-        private String notificationTime;
+        private LocalTime notificationTime;
         private String space;
         private Chores.RepeatType repeatType;
         private Integer repeatInterval;
@@ -67,7 +68,7 @@ public class ChoresDto {
                 .id(chores.getId())
                 .title(chores.getTitle())
                 .notificationYn(chores.getNotificationYn())
-                .notificationTime(String.valueOf(chores.getNotificationTime()))
+                .notificationTime(chores.getNotificationTime())
                 .space(chores.getSpace())
                 .repeatType(chores.getRepeatType())
                 .repeatInterval(chores.getRepeatInterval())

--- a/src/main/java/com/zerobase/homemate/chores/dto/ChoresDto.java
+++ b/src/main/java/com/zerobase/homemate/chores/dto/ChoresDto.java
@@ -1,0 +1,83 @@
+package com.zerobase.homemate.chores.dto;
+
+import com.zerobase.homemate.entity.Chores;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class ChoresDto {
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class CreateRequest {
+        @NotBlank(message = "집안일 제목은 필수입니다")
+        private String title;
+
+        @NotNull(message = "알림 여부는 필수입니다")
+        private Boolean notificationYn;
+
+        private String notificationTime;
+
+        private String space;
+
+        @NotNull(message = "반복 타입은 필수입니다")
+        private Chores.RepeatType repeatType;
+
+        private Integer repeatInterval;
+
+        @NotNull(message = "시작 일자는 필수입니다")
+        private LocalDate startDate;
+
+        @NotNull(message = "종료 일자는 필수입니다")
+        private LocalDate endDate;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Getter
+    @Setter
+    public static class Response {
+        private Long id;
+        private String title;
+        private Boolean notificationYn;
+        private String notificationTime;
+        private String space;
+        private Chores.RepeatType repeatType;
+        private Integer repeatInterval;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private Boolean isDeleted;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private LocalDateTime deletedAt;
+
+        public static Response fromEntity(Chores chores) {
+            return Response.builder()
+                .id(chores.getId())
+                .title(chores.getTitle())
+                .notificationYn(chores.getNotificationYn())
+                .notificationTime(String.valueOf(chores.getNotificationTime()))
+                .space(chores.getSpace())
+                .repeatType(chores.getRepeatType())
+                .repeatInterval(chores.getRepeatInterval())
+                .startDate(chores.getStartDate())
+                .endDate(chores.getEndDate())
+                .isDeleted(chores.getIsDeleted())
+                .createdAt(chores.getCreatedAt())
+                .updatedAt(chores.getUpdatedAt())
+                .deletedAt(chores.getDeletedAt())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/zerobase/homemate/chores/service/ChoresService.java
+++ b/src/main/java/com/zerobase/homemate/chores/service/ChoresService.java
@@ -6,7 +6,6 @@ import com.zerobase.homemate.entity.ChoreInstances;
 import com.zerobase.homemate.repository.ChoresRepository;
 import com.zerobase.homemate.repository.ChoreInstancesRepository;
 import com.zerobase.homemate.util.ChoreInstanceGenerator;
-import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,30 +25,23 @@ public class ChoresService {
     public ChoresDto.Response createChores(Long userId,
         ChoresDto.CreateRequest request) {
 
-        try {
-            Chores chores = Chores.builder()
-                    .userId(userId)
-                    .title(request.getTitle())
-                    .notificationYn(request.getNotificationYn())
-                    .notificationTime(
-                        LocalTime.parse(request.getNotificationTime()))
-                    .space(request.getSpace())
-                    .repeatType(request.getRepeatType())
-                    .repeatInterval(request.getRepeatInterval())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .isDeleted(false)
-                    .build();
+        Chores chores = Chores.builder()
+                .userId(userId)
+                .title(request.getTitle())
+                .notificationYn(request.getNotificationYn())
+                .notificationTime(request.getNotificationTime())
+                .space(request.getSpace())
+                .repeatType(request.getRepeatType())
+                .repeatInterval(request.getRepeatInterval())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .isDeleted(false)
+                .build();
 
-            Chores savedChores = choresRepository.save(chores);
-            List<ChoreInstances> instances = choreInstanceGenerator.generateInstances(savedChores);
-            choreInstancesRepository.saveAll(instances);
+        Chores savedChores = choresRepository.save(chores);
+        List<ChoreInstances> instances = choreInstanceGenerator.generateInstances(savedChores);
+        choreInstancesRepository.saveAll(instances);
 
-          return ChoresDto.Response.fromEntity(savedChores);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
-        }
+        return ChoresDto.Response.fromEntity(savedChores);
     }
 }

--- a/src/main/java/com/zerobase/homemate/chores/service/ChoresService.java
+++ b/src/main/java/com/zerobase/homemate/chores/service/ChoresService.java
@@ -1,0 +1,55 @@
+package com.zerobase.homemate.chores.service;
+
+import com.zerobase.homemate.chores.dto.ChoresDto;
+import com.zerobase.homemate.entity.Chores;
+import com.zerobase.homemate.entity.ChoreInstances;
+import com.zerobase.homemate.repository.ChoresRepository;
+import com.zerobase.homemate.repository.ChoreInstancesRepository;
+import com.zerobase.homemate.util.ChoreInstanceGenerator;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChoresService {
+
+    private final ChoresRepository choresRepository;
+    private final ChoreInstancesRepository choreInstancesRepository;
+    private final ChoreInstanceGenerator choreInstanceGenerator;
+
+    @Transactional
+    public ChoresDto.Response createChores(Long userId,
+        ChoresDto.CreateRequest request) {
+
+        try {
+            Chores chores = Chores.builder()
+                    .userId(userId)
+                    .title(request.getTitle())
+                    .notificationYn(request.getNotificationYn())
+                    .notificationTime(
+                        LocalTime.parse(request.getNotificationTime()))
+                    .space(request.getSpace())
+                    .repeatType(request.getRepeatType())
+                    .repeatInterval(request.getRepeatInterval())
+                    .startDate(request.getStartDate())
+                    .endDate(request.getEndDate())
+                    .isDeleted(false)
+                    .build();
+
+            Chores savedChores = choresRepository.save(chores);
+            List<ChoreInstances> instances = choreInstanceGenerator.generateInstances(savedChores);
+            choreInstancesRepository.saveAll(instances);
+
+          return ChoresDto.Response.fromEntity(savedChores);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/zerobase/homemate/entity/ChoreInstances.java
+++ b/src/main/java/com/zerobase/homemate/entity/ChoreInstances.java
@@ -1,0 +1,58 @@
+package com.zerobase.homemate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chore_instances")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class ChoreInstances {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "chore_id", nullable = false)
+    private Long choreId;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDate dueDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private Status status = Status.PENDING;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chore_id", insertable = false, updatable = false)
+    private Chores chore;
+
+    public enum Status {
+        PENDING, COMPLETED
+    }
+}

--- a/src/main/java/com/zerobase/homemate/entity/Chores.java
+++ b/src/main/java/com/zerobase/homemate/entity/Chores.java
@@ -1,0 +1,88 @@
+package com.zerobase.homemate.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "chores")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Chores {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "title", nullable = false, length = 30)
+    private String title;
+
+    @Column(name = "notification_yn", nullable = false)
+    private Boolean notificationYn;
+
+    @Column(name = "notification_time", nullable = false)
+    private LocalTime notificationTime;
+
+    @Column(name = "space", length = 10)
+    private String space;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "repeat_type", nullable = false)
+    private RepeatType repeatType;
+
+    @Column(name = "repeat_interval")
+    private Integer repeatInterval;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    // Users 테이블 완성되면 추가
+    /* @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", insertable = false, updatable = false)
+    private Users user;
+    */
+
+    @OneToMany(mappedBy = "chore", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<ChoreInstances> choreInstances = new ArrayList<>();
+
+    public enum RepeatType {
+        NONE, DAILY, WEEKLY, MONTHLY, YEARLY
+    }
+}

--- a/src/main/java/com/zerobase/homemate/repository/ChoreInstancesRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoreInstancesRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.homemate.repository;
+
+import com.zerobase.homemate.entity.ChoreInstances;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChoreInstancesRepository extends JpaRepository<ChoreInstances, Long> {
+
+}

--- a/src/main/java/com/zerobase/homemate/repository/ChoresRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoresRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.homemate.repository;
+
+import com.zerobase.homemate.entity.Chores;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChoresRepository extends JpaRepository<Chores, Long> {
+
+}

--- a/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
+++ b/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
@@ -1,0 +1,117 @@
+package com.zerobase.homemate.util;
+
+import com.zerobase.homemate.entity.Chores;
+import com.zerobase.homemate.entity.ChoreInstances;
+import com.zerobase.homemate.exception.CustomException;
+import com.zerobase.homemate.exception.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ChoreInstanceGenerator {
+
+    private static final int MAX_INSTANCES = 1000; // 최대 인스턴스 수 제한
+
+    public List<ChoreInstances> generateInstances(Chores chores) {
+        try {
+
+            validateChoreData(chores);
+            List<ChoreInstances> instances = new ArrayList<>();
+            
+            if (chores.getRepeatType() == Chores.RepeatType.NONE) {
+                instances.add(createInstance(chores, chores.getStartDate()));
+            } else {
+                LocalDate currentDate = chores.getStartDate();
+                LocalDate endDate = chores.getEndDate() != null ? chores.getEndDate() : chores.getStartDate().plusYears(1);
+                
+                int instanceCount = 0;
+                while (!currentDate.isAfter(endDate) && instanceCount < MAX_INSTANCES) {
+                    instances.add(createInstance(chores, currentDate));
+                    currentDate = getNextDate(currentDate, chores.getRepeatType(), chores.getRepeatInterval());
+                    instanceCount++;
+                }
+
+                if (instanceCount >= MAX_INSTANCES) {
+                    throw new CustomException(ErrorCode.TOO_MANY_INSTANCES);
+                }
+            }
+            
+            return instances;
+            
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.INVALID_DATE_FORMAT, "날짜 형식이 올바르지 않습니다: " + e.getMessage());
+        } catch (Exception e) {
+            if (e instanceof CustomException) {
+                throw e;
+            }
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "인스턴스 생성 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+    
+    private void validateChoreData(Chores chores) {
+        if (chores.getStartDate() == null) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "시작일은 필수입니다.");
+        }
+
+        if (chores.getRepeatType() != Chores.RepeatType.NONE && chores.getEndDate() != null) {
+            if (chores.getEndDate().isBefore(chores.getStartDate())) {
+                throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
+            }
+        }
+
+        if (chores.getRepeatType() != Chores.RepeatType.NONE) {
+            if (chores.getRepeatInterval() != null && chores.getRepeatInterval() <= 0) {
+                throw new CustomException(ErrorCode.INVALID_REPEAT_INTERVAL);
+            }
+        }
+
+        if (chores.getNotificationYn() && chores.getNotificationTime() != null) {
+            validateNotificationTime(
+                String.valueOf(chores.getNotificationTime()));
+        }
+    }
+    
+    private void validateNotificationTime(String notificationTime) {
+        try {
+            String[] timeParts = notificationTime.split(":");
+            if (timeParts.length != 2) {
+                throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TIME);
+            }
+            
+            int hour = Integer.parseInt(timeParts[0]);
+            int minute = Integer.parseInt(timeParts[1]);
+            
+            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+                throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TIME);
+            }
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TIME);
+        }
+    }
+    
+    private ChoreInstances createInstance(Chores chores, LocalDate dueDate) {
+        return ChoreInstances.builder()
+                .choreId(chores.getId())
+                .dueDate(dueDate)
+                .status(ChoreInstances.Status.PENDING)
+                .build();
+    }
+    
+    private LocalDate getNextDate(LocalDate currentDate, Chores.RepeatType repeatType, Integer repeatInterval) {
+        if (repeatInterval == null || repeatInterval <= 0) {
+            repeatInterval = 1;
+        }
+        
+        return switch (repeatType) {
+            case DAILY -> currentDate.plusDays(repeatInterval);
+            case WEEKLY -> currentDate.plusWeeks(repeatInterval);
+            case MONTHLY -> currentDate.plusMonths(repeatInterval);
+            case YEARLY -> currentDate.plusYears(repeatInterval);
+            default -> currentDate.plusDays(1);
+        };
+    }
+}

--- a/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
+++ b/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
@@ -7,7 +7,6 @@ import com.zerobase.homemate.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,82 +16,32 @@ public class ChoreInstanceGenerator {
     private static final int MAX_INSTANCES = 1000; // 최대 인스턴스 수 제한
 
     public List<ChoreInstances> generateInstances(Chores chores) {
-        try {
+        List<ChoreInstances> instances = new ArrayList<>();
 
-            validateChoreData(chores);
-            List<ChoreInstances> instances = new ArrayList<>();
-            
-            if (chores.getRepeatType() == Chores.RepeatType.NONE) {
-                instances.add(createInstance(chores, chores.getStartDate()));
-            } else {
-                LocalDate currentDate = chores.getStartDate();
-                LocalDate endDate = chores.getEndDate() != null ? chores.getEndDate() : chores.getStartDate().plusYears(1);
-                
-                int instanceCount = 0;
-                while (!currentDate.isAfter(endDate) && instanceCount < MAX_INSTANCES) {
-                    instances.add(createInstance(chores, currentDate));
-                    currentDate = getNextDate(currentDate, chores.getRepeatType(), chores.getRepeatInterval());
-                    instanceCount++;
-                }
+        if (chores.getRepeatType() == Chores.RepeatType.NONE) {
+            instances.add(createInstance(chores, chores.getStartDate()));
+        } else {
+            LocalDate currentDate = chores.getStartDate();
+            LocalDate endDate = chores.getEndDate();
 
-                if (instanceCount >= MAX_INSTANCES) {
-                    throw new CustomException(ErrorCode.TOO_MANY_INSTANCES);
-                }
+            int instanceCount = 0;
+            while (!currentDate.isAfter(endDate)) {
+                instances.add(createInstance(chores, currentDate));
+                currentDate = getNextDate(
+                    currentDate,
+                    chores.getRepeatType(),
+                    chores.getRepeatInterval());
+                instanceCount++;
             }
-            
-            return instances;
-            
-        } catch (DateTimeParseException e) {
-            throw new CustomException(ErrorCode.INVALID_DATE_FORMAT, "날짜 형식이 올바르지 않습니다: " + e.getMessage());
-        } catch (Exception e) {
-            if (e instanceof CustomException) {
-                throw e;
+
+            if (instanceCount >= MAX_INSTANCES) {
+                throw new CustomException(ErrorCode.TOO_MANY_INSTANCES);
             }
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "인스턴스 생성 중 오류가 발생했습니다: " + e.getMessage());
         }
+
+        return instances;
     }
-    
-    private void validateChoreData(Chores chores) {
-        if (chores.getStartDate() == null) {
-            throw new CustomException(ErrorCode.VALIDATION_ERROR, "시작일은 필수입니다.");
-        }
 
-        if (chores.getRepeatType() != Chores.RepeatType.NONE && chores.getEndDate() != null) {
-            if (chores.getEndDate().isBefore(chores.getStartDate())) {
-                throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
-            }
-        }
-
-        if (chores.getRepeatType() != Chores.RepeatType.NONE) {
-            if (chores.getRepeatInterval() != null && chores.getRepeatInterval() <= 0) {
-                throw new CustomException(ErrorCode.INVALID_REPEAT_INTERVAL);
-            }
-        }
-
-        if (chores.getNotificationYn() && chores.getNotificationTime() != null) {
-            validateNotificationTime(
-                String.valueOf(chores.getNotificationTime()));
-        }
-    }
-    
-    private void validateNotificationTime(String notificationTime) {
-        try {
-            String[] timeParts = notificationTime.split(":");
-            if (timeParts.length != 2) {
-                throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TIME);
-            }
-            
-            int hour = Integer.parseInt(timeParts[0]);
-            int minute = Integer.parseInt(timeParts[1]);
-            
-            if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
-                throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TIME);
-            }
-        } catch (NumberFormatException e) {
-            throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TIME);
-        }
-    }
-    
     private ChoreInstances createInstance(Chores chores, LocalDate dueDate) {
         return ChoreInstances.builder()
                 .choreId(chores.getId())
@@ -100,12 +49,9 @@ public class ChoreInstanceGenerator {
                 .status(ChoreInstances.Status.PENDING)
                 .build();
     }
-    
-    private LocalDate getNextDate(LocalDate currentDate, Chores.RepeatType repeatType, Integer repeatInterval) {
-        if (repeatInterval == null || repeatInterval <= 0) {
-            repeatInterval = 1;
-        }
-        
+
+    private LocalDate getNextDate(LocalDate currentDate,
+        Chores.RepeatType repeatType, Integer repeatInterval) {
         return switch (repeatType) {
             case DAILY -> currentDate.plusDays(repeatInterval);
             case WEEKLY -> currentDate.plusWeeks(repeatInterval);


### PR DESCRIPTION
## 📝 계획
## 💡PR에서 핵심적으로 변경된 사항
- ERD 에 맞춰 chores, chore_instances 테이블과 매핑하는 Entity 작성
- API 명세서와 동일한 Dto (Request, Response) 형식의 Service 작성

## 📢이외 추가 변경 부분 및 기타
- 집안일 추가 시 인스턴스에 따른 알림도 생성되어야 하지만, 아직 알림 기능 미구현으로 추후 연동 예정입니다.

## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 
Postman 으로 API 호출
<img width="1274" height="823" alt="image" src="https://github.com/user-attachments/assets/4b034421-6da1-4163-9db4-d0e538a913e3" />

DB에도 집안일 1개, 반복주기에 따른 집안일 인스턴스 3개 정상적으로 생성 확인
<img width="1616" height="131" alt="image" src="https://github.com/user-attachments/assets/109c1f24-9050-4c66-afde-bf7e97cee7d8" />
<img width="1424" height="189" alt="image" src="https://github.com/user-attachments/assets/d62bca7b-4bce-4edd-9fd6-2b97cace89a8" />
