### PR TITLE
[feat] 알림 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/homemate/entity/Notification.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notification.java
@@ -1,0 +1,71 @@
+package com.zerobase.homemate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    // TODO: User, Chore, ChoreInstance 연관관계 추가
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Category category;
+
+    @Column(name = "title", nullable = false, length = 30)
+    private String title;
+
+    @Column(name = "message", columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "scheduled_at", nullable = false)
+    private LocalDateTime scheduledAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Category {
+        CHORE,
+        NOTICE
+    }
+
+    public enum Status {
+        SCHEDULED,
+        SENT,
+        CANCELLED
+    }
+}

--- a/src/main/java/com/zerobase/homemate/entity/Notification.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notification.java
@@ -26,6 +26,12 @@ public class Notification {
     private Long id;
 
     // TODO: User, Chore, ChoreInstance 연관관계 추가
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    @Column(name = "chore_id", nullable = false)
+    private Long choreId;
+    @Column(name = "chore_instance_id", nullable = false)
+    private Long choreInstanceId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "category", nullable = false)

--- a/src/main/java/com/zerobase/homemate/entity/Notification.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notification.java
@@ -1,5 +1,7 @@
 package com.zerobase.homemate.entity;
 
+import com.zerobase.homemate.entity.enums.Category;
+import com.zerobase.homemate.entity.enums.NotificationStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,8 +49,8 @@ public class Notification {
     private LocalDateTime scheduledAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private Status status;
+    @Column(name = "notification_status", nullable = false)
+    private NotificationStatus notificationStatus;
 
     @Column(name = "is_read", nullable = false, columnDefinition = "BOOLEAN")
     private Boolean isRead;
@@ -64,14 +66,4 @@ public class Notification {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public enum Category {
-        CHORE,
-        NOTICE
-    }
-
-    public enum Status {
-        SCHEDULED,
-        SENT,
-        CANCELLED
-    }
 }

--- a/src/main/java/com/zerobase/homemate/entity/Notification.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notification.java
@@ -44,7 +44,7 @@ public class Notification {
     @Column(name = "status", nullable = false)
     private Status status;
 
-    @Column(name = "is_read", nullable = false)
+    @Column(name = "is_read", nullable = false, columnDefinition = "BOOLEAN")
     private Boolean isRead;
 
     @Column(name = "read_at")

--- a/src/main/java/com/zerobase/homemate/entity/Notification.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notification.java
@@ -1,6 +1,6 @@
 package com.zerobase.homemate.entity;
 
-import com.zerobase.homemate.entity.enums.Category;
+import com.zerobase.homemate.entity.enums.NotificationCategory;
 import com.zerobase.homemate.entity.enums.NotificationStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -36,8 +36,8 @@ public class Notification {
     private Long choreInstanceId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "category", nullable = false)
-    private Category category;
+    @Column(name = "notification_category", nullable = false)
+    private NotificationCategory notificationCategory;
 
     @Column(name = "title", nullable = false, length = 30)
     private String title;

--- a/src/main/java/com/zerobase/homemate/entity/enums/Category.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/Category.java
@@ -1,6 +1,0 @@
-package com.zerobase.homemate.entity.enums;
-
-public enum Category {
-    CHORE,
-    NOTICE
-}

--- a/src/main/java/com/zerobase/homemate/entity/enums/Category.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/Category.java
@@ -1,0 +1,6 @@
+package com.zerobase.homemate.entity.enums;
+
+public enum Category {
+    CHORE,
+    NOTICE
+}

--- a/src/main/java/com/zerobase/homemate/entity/enums/NotificationCategory.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/NotificationCategory.java
@@ -1,0 +1,18 @@
+package com.zerobase.homemate.entity.enums;
+
+import com.zerobase.homemate.exception.CustomException;
+import com.zerobase.homemate.exception.ErrorCode;
+
+public enum NotificationCategory {
+    CHORE,
+    NOTICE;
+
+    // valueOf에서 발생하는 예외를 CustomException으로 전환
+    public static NotificationCategory from(String value) {
+        try {
+            return NotificationCategory.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "잘못된 카테고리 입력입니다.");
+        }
+    }
+}

--- a/src/main/java/com/zerobase/homemate/entity/enums/NotificationStatus.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/NotificationStatus.java
@@ -1,0 +1,7 @@
+package com.zerobase.homemate.entity.enums;
+
+public enum NotificationStatus {
+    SCHEDULED,
+    SENT,
+    CANCELLED
+}

--- a/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
+++ b/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package com.zerobase.homemate.notification.controller;
+
+import com.zerobase.homemate.entity.enums.NotificationCategory;
+import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<List<NotificationDto>> getNotifications(
+            @RequestParam(name = "category", defaultValue = "ALL") String category
+    ) {
+        Long userId = 1L; // TODO: 인증에서 userId 가져오기
+
+        if ("ALL".equals(category)) {
+            List<NotificationDto> result = notificationService.getNotifications(userId);
+
+            return ResponseEntity.ok(result);
+        }
+
+        NotificationCategory notificationCategory = NotificationCategory.from(category); // 유효하지 않은 카테고리 입력시 여기서 예외 발생
+        List<NotificationDto> result = notificationService.getNotificationsByCategory(userId, notificationCategory);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
+++ b/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
@@ -25,7 +25,7 @@ public class NotificationController {
     ) {
         Long userId = 1L; // TODO: 인증에서 userId 가져오기
 
-        if ("ALL".equals(category)) {
+        if ("ALL".equalsIgnoreCase(category)) {
             List<NotificationDto> result = notificationService.getNotifications(userId);
 
             return ResponseEntity.ok(result);

--- a/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
+++ b/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 public class NotificationDto {
 
     private Long id;
+    private Long userId;
     private Long choreId;
     private Long choreInstanceId;
     private NotificationCategory notificationCategory;
@@ -32,6 +33,7 @@ public class NotificationDto {
     public static NotificationDto fromEntity(Notification notification) {
         return NotificationDto.builder()
                 .id(notification.getId())
+                .userId(notification.getUserId())
                 .choreId(notification.getChoreId())
                 .choreInstanceId(notification.getChoreInstanceId())
                 .notificationCategory(notification.getNotificationCategory())

--- a/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
+++ b/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
@@ -1,6 +1,8 @@
 package com.zerobase.homemate.notification.dto;
 
 import com.zerobase.homemate.entity.Notification;
+import com.zerobase.homemate.entity.enums.Category;
+import com.zerobase.homemate.entity.enums.NotificationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,11 +19,11 @@ public class NotificationDto {
     private Long id;
     private Long choreId;
     private Long choreInstanceId;
-    private Notification.Category category;
+    private Category category;
     private String title;
     private String message;
     private LocalDateTime scheduledAt;
-    private Notification.Status status;
+    private NotificationStatus notificationStatus;
     private Boolean isRead;
     private LocalDateTime readAt;
     private LocalDateTime createdAt;
@@ -36,7 +38,7 @@ public class NotificationDto {
                 .title(notification.getTitle())
                 .message(notification.getMessage())
                 .scheduledAt(notification.getScheduledAt())
-                .status(notification.getStatus())
+                .notificationStatus(notification.getNotificationStatus())
                 .isRead(notification.getIsRead())
                 .readAt(notification.getReadAt())
                 .createdAt(notification.getCreatedAt())

--- a/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
+++ b/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
@@ -1,0 +1,46 @@
+package com.zerobase.homemate.notification.dto;
+
+import com.zerobase.homemate.entity.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationDto {
+
+    private Long id;
+    private Long choreId;
+    private Long choreInstanceId;
+    private Notification.Category category;
+    private String title;
+    private String message;
+    private LocalDateTime scheduledAt;
+    private Notification.Status status;
+    private Boolean isRead;
+    private LocalDateTime readAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static NotificationDto fromEntity(Notification notification) {
+        return NotificationDto.builder()
+                .id(notification.getId())
+                .choreId(notification.getChoreId())
+                .choreInstanceId(notification.getChoreInstanceId())
+                .category(notification.getCategory())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .scheduledAt(notification.getScheduledAt())
+                .status(notification.getStatus())
+                .isRead(notification.getIsRead())
+                .readAt(notification.getReadAt())
+                .createdAt(notification.getCreatedAt())
+                .updatedAt(notification.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
+++ b/src/main/java/com/zerobase/homemate/notification/dto/NotificationDto.java
@@ -1,7 +1,7 @@
 package com.zerobase.homemate.notification.dto;
 
 import com.zerobase.homemate.entity.Notification;
-import com.zerobase.homemate.entity.enums.Category;
+import com.zerobase.homemate.entity.enums.NotificationCategory;
 import com.zerobase.homemate.entity.enums.NotificationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +19,7 @@ public class NotificationDto {
     private Long id;
     private Long choreId;
     private Long choreInstanceId;
-    private Category category;
+    private NotificationCategory notificationCategory;
     private String title;
     private String message;
     private LocalDateTime scheduledAt;
@@ -34,7 +34,7 @@ public class NotificationDto {
                 .id(notification.getId())
                 .choreId(notification.getChoreId())
                 .choreInstanceId(notification.getChoreInstanceId())
-                .category(notification.getCategory())
+                .notificationCategory(notification.getNotificationCategory())
                 .title(notification.getTitle())
                 .message(notification.getMessage())
                 .scheduledAt(notification.getScheduledAt())

--- a/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
+++ b/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.zerobase.homemate.notification.service;
 
 import com.zerobase.homemate.entity.Notification;
+import com.zerobase.homemate.entity.enums.NotificationCategory;
 import com.zerobase.homemate.notification.dto.NotificationDto;
 import com.zerobase.homemate.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,15 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     @Transactional(readOnly = true)
-    public List<NotificationDto> getNotifications(Long userId, Notification.Category category) {
-        List<Notification> list = notificationRepository.findAllByUser_IdAndCategory(userId, category);
+    public List<NotificationDto> getNotifications(Long userId) {
+        List<Notification> list = notificationRepository.findAllByUserId(userId);
+
+        return list.stream().map(NotificationDto::fromEntity).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationDto> getNotificationsByCategory(Long userId, NotificationCategory category) {
+        List<Notification> list = notificationRepository.findAllByUserIdAndNotificationCategory(userId, category);
 
         return list.stream().map(NotificationDto::fromEntity).toList();
     }

--- a/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
+++ b/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
@@ -1,0 +1,24 @@
+package com.zerobase.homemate.notification.service;
+
+import com.zerobase.homemate.entity.Notification;
+import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public List<NotificationDto> getNotifications(Long userId, Notification.Category category) {
+        List<Notification> list = notificationRepository.findAllByUser_IdAndCategory(userId, category);
+
+        return list.stream().map(NotificationDto::fromEntity).toList();
+    }
+}

--- a/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    List<Notification> findAllByUserId(Long userId);
+
     List<Notification> findAllByUserIdAndNotificationCategory(Long userId, NotificationCategory notificationCategory);
 }

--- a/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
@@ -1,11 +1,12 @@
 package com.zerobase.homemate.repository;
 
 import com.zerobase.homemate.entity.Notification;
+import com.zerobase.homemate.entity.enums.NotificationCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> findAllByUser_IdAndCategory(Long userId, Notification.Category category);
+    List<Notification> findAllByUserIdAndNotificationCategory(Long userId, NotificationCategory notificationCategory);
 }

--- a/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
@@ -3,6 +3,9 @@ package com.zerobase.homemate.repository;
 import com.zerobase.homemate.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
+    List<Notification> findAllByUser_IdAndCategory(Long userId, Notification.Category category);
 }

--- a/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.zerobase.homemate.repository;
+
+import com.zerobase.homemate.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -1,11 +1,13 @@
 package com.zerobase.homemate.notification.controller;
 
-import com.zerobase.homemate.entity.enums.NotificationCategory;
 import com.zerobase.homemate.entity.enums.NotificationStatus;
 import com.zerobase.homemate.exception.GlobalExceptionHandler;
 import com.zerobase.homemate.notification.dto.NotificationDto;
 import com.zerobase.homemate.notification.service.NotificationService;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -17,12 +19,14 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.zerobase.homemate.entity.enums.NotificationCategory.*;
+import static com.zerobase.homemate.entity.enums.NotificationCategory.CHORE;
+import static com.zerobase.homemate.entity.enums.NotificationCategory.NOTICE;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(NotificationController.class)
 @Import(GlobalExceptionHandler.class)

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,131 @@
+package com.zerobase.homemate.notification.controller;
+
+import com.zerobase.homemate.entity.enums.NotificationCategory;
+import com.zerobase.homemate.entity.enums.NotificationStatus;
+import com.zerobase.homemate.exception.GlobalExceptionHandler;
+import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.notification.service.NotificationService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.zerobase.homemate.entity.enums.NotificationCategory.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(NotificationController.class)
+@Import(GlobalExceptionHandler.class)
+@WithMockUser(username = "user1", roles = "USER")
+class NotificationControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    NotificationService notificationService;
+
+    private List<NotificationDto> notificationDtos = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime baseDateTime = LocalDateTime.now().withHour(12).withMinute(0).withSecond(0);
+
+        notificationDtos = List.of(
+                new NotificationDto(1L, 1L, 1L, 1L, CHORE, "화장실 청소", "", baseDateTime.plusDays(1), NotificationStatus.SCHEDULED, false, null, null, null),
+                new NotificationDto(2L, 1L, 2L, 2L, CHORE, "쓰레기 버리기", "", baseDateTime.minusDays(1), NotificationStatus.SENT, true, baseDateTime.minusDays(1).plusHours(6), null, null),
+                new NotificationDto(3L, null, null, null, NOTICE, "공지 사항", "", baseDateTime, NotificationStatus.SENT, false, null, null, null),
+                new NotificationDto(4L, 1L, 2L, 3L, CHORE, "쓰레기 버리기", "", baseDateTime.plusDays(3), NotificationStatus.SCHEDULED, false, null, null, null)
+        );
+    }
+
+    @Nested
+    @DisplayName("GET /notifications")
+    class GetNotifications {
+
+        @Test
+        @DisplayName("(no category) -> 200 OK")
+        void success_WithNoCategory() throws Exception {
+            // given
+            Long userId = 1L;
+            when(notificationService.getNotifications(userId)).thenReturn(notificationDtos);
+
+            // when & then
+            mockMvc.perform(get("/notifications"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(notificationDtos.size())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(NOTICE.toString())));
+        }
+
+        @Test
+        @DisplayName("?category=ALL -> 200 OK")
+        void success_WithCategoryAll() throws Exception {
+            // given
+            Long userId = 1L;
+            when(notificationService.getNotifications(userId)).thenReturn(notificationDtos);
+
+            // when & then
+            mockMvc.perform(get("/notifications?category=ALL"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(notificationDtos.size())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(NOTICE.toString())));
+        }
+
+        @Test
+        @DisplayName("?category=CHORE -> 200 OK")
+        void success_WithCategoryChore() throws Exception {
+            // given
+            Long userId = 1L;
+            List<NotificationDto> choreList = notificationDtos.stream().filter(e -> CHORE.equals(e.getNotificationCategory())).toList();
+            when(notificationService.getNotificationsByCategory(userId, CHORE)).thenReturn(choreList);
+
+            // when & then
+            mockMvc.perform(get("/notifications?category=CHORE"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(choreList.size())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())))
+                    .andExpect(jsonPath("$[*].notificationCategory", not(hasItem(NOTICE.toString()))));
+        }
+
+        @Test
+        @DisplayName("?category=NOTICE -> 200 OK")
+        void success_WithCategoryNotice() throws Exception {
+            // given
+            Long userId = 1L;
+            List<NotificationDto> noticeList = notificationDtos.stream().filter(e -> NOTICE.equals(e.getNotificationCategory())).toList();
+            when(notificationService.getNotificationsByCategory(userId, NOTICE)).thenReturn(noticeList);
+
+            // when & then
+            mockMvc.perform(get("/notifications?category=NOTICE"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(noticeList.size())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(NOTICE.toString())))
+                    .andExpect(jsonPath("$[*].notificationCategory", not(hasItem(CHORE.toString()))));
+        }
+
+        @Test
+        @DisplayName("?category=WRONG -> 400 Bad Request")
+        void success_WithWrongCategory() throws Exception {
+            // given
+            Long userId = 1L;
+
+            // when & then
+            mockMvc.perform(get("/notifications?category=WRONG"))
+                    .andExpect(status().isBadRequest());
+
+            verifyNoInteractions(notificationService);
+        }
+    }
+}

--- a/src/test/java/com/zerobase/homemate/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/service/NotificationServiceTest.java
@@ -1,8 +1,6 @@
 package com.zerobase.homemate.notification.service;
 
 import com.zerobase.homemate.entity.Notification;
-import com.zerobase.homemate.entity.enums.NotificationCategory;
-import com.zerobase.homemate.entity.enums.NotificationStatus;
 import com.zerobase.homemate.notification.dto.NotificationDto;
 import com.zerobase.homemate.repository.NotificationRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +14,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.zerobase.homemate.entity.enums.NotificationCategory.CHORE;
+import static com.zerobase.homemate.entity.enums.NotificationStatus.SCHEDULED;
+import static com.zerobase.homemate.entity.enums.NotificationStatus.SENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -40,10 +41,10 @@ class NotificationServiceTest {
                 .userId(1L)
                 .choreId(1L)
                 .choreInstanceId(1L)
-                .notificationCategory(NotificationCategory.CHORE)
+                .notificationCategory(CHORE)
                 .title("화장실 청소")
                 .scheduledAt(baseDateTime.plusDays(1))
-                .notificationStatus(NotificationStatus.SCHEDULED)
+                .notificationStatus(SCHEDULED)
                 .isRead(false)
                 .readAt(null)
                 .build();
@@ -53,10 +54,10 @@ class NotificationServiceTest {
                 .userId(1L)
                 .choreId(2L)
                 .choreInstanceId(2L)
-                .notificationCategory(NotificationCategory.CHORE)
+                .notificationCategory(CHORE)
                 .title("쓰레기 버리기")
                 .scheduledAt(baseDateTime.minusDays(1))
-                .notificationStatus(NotificationStatus.SENT)
+                .notificationStatus(SENT)
                 .isRead(true)
                 .readAt(baseDateTime.minusDays(1).plusHours(1))
                 .build();
@@ -85,12 +86,12 @@ class NotificationServiceTest {
         Long userId = 1L;
 
         List<Notification> choreList = notifications.stream()
-                .filter(e -> NotificationCategory.CHORE.equals(e.getNotificationCategory()))
+                .filter(e -> CHORE.equals(e.getNotificationCategory()))
                 .toList();
-        when(notificationRepository.findAllByUserIdAndNotificationCategory(userId, NotificationCategory.CHORE)).thenReturn(choreList);
+        when(notificationRepository.findAllByUserIdAndNotificationCategory(userId, CHORE)).thenReturn(choreList);
 
         // when
-        List<NotificationDto> result = notificationService.getNotificationsByCategory(userId, NotificationCategory.CHORE);
+        List<NotificationDto> result = notificationService.getNotificationsByCategory(userId, CHORE);
 
         // then
         assertThat(result.size()).isEqualTo(choreList.size());

--- a/src/test/java/com/zerobase/homemate/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/service/NotificationServiceTest.java
@@ -1,0 +1,98 @@
+package com.zerobase.homemate.notification.service;
+
+import com.zerobase.homemate.entity.Notification;
+import com.zerobase.homemate.entity.enums.NotificationCategory;
+import com.zerobase.homemate.entity.enums.NotificationStatus;
+import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private List<Notification> notifications = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime baseDateTime = LocalDateTime.now().withHour(12).withMinute(0).withSecond(0);
+
+        Notification notification1 = Notification.builder()
+                .id(1L)
+                .userId(1L)
+                .choreId(1L)
+                .choreInstanceId(1L)
+                .notificationCategory(NotificationCategory.CHORE)
+                .title("화장실 청소")
+                .scheduledAt(baseDateTime.plusDays(1))
+                .notificationStatus(NotificationStatus.SCHEDULED)
+                .isRead(false)
+                .readAt(null)
+                .build();
+
+        Notification notification2 = Notification.builder()
+                .id(2L)
+                .userId(1L)
+                .choreId(2L)
+                .choreInstanceId(2L)
+                .notificationCategory(NotificationCategory.CHORE)
+                .title("쓰레기 버리기")
+                .scheduledAt(baseDateTime.minusDays(1))
+                .notificationStatus(NotificationStatus.SENT)
+                .isRead(true)
+                .readAt(baseDateTime.minusDays(1).plusHours(1))
+                .build();
+
+        notifications.addAll(List.of(notification1, notification2));
+    }
+
+    @Test
+    void getNotifications_Success() {
+        // given
+        Long userId = 1L;
+
+        List<Notification> list = notifications.stream().filter(e -> e.getUserId().equals(userId)).toList();
+        when(notificationRepository.findAllByUserId(userId)).thenReturn(list);
+
+        // when
+        List<NotificationDto> result = notificationService.getNotifications(userId);
+
+        // then
+        assertThat(result.size()).isEqualTo(list.size());
+    }
+
+    @Test
+    void getNotificationsByCategory_Success_WithCategoryChore() {
+        // given
+        Long userId = 1L;
+
+        List<Notification> choreList = notifications.stream()
+                .filter(e -> NotificationCategory.CHORE.equals(e.getNotificationCategory()))
+                .toList();
+        when(notificationRepository.findAllByUserIdAndNotificationCategory(userId, NotificationCategory.CHORE)).thenReturn(choreList);
+
+        // when
+        List<NotificationDto> result = notificationService.getNotificationsByCategory(userId, NotificationCategory.CHORE);
+
+        // then
+        assertThat(result.size()).isEqualTo(choreList.size());
+    }
+}


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획

- 알림 리스트 조회를 위한 기초 기능 구현

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- 엔티티,리포지토리 구성: `Notification`, `NotificationRepository`
  - 엔티티에 포함된 Enum: `NotificationCategory`, `NotificationStatus`
  - 추후 엔티티 완성시에 userId, choreId, choreInstanceId는 해당하는 객체와 연관관계 설정 예정
- 컨트롤러: `NotificationController`
  - 알림 리스트 조회 메서드: `getNotifications`
    - `GET /notifications?category=""` -> `200 OK` 응답
    - category는 ALL, CHORE, NOTICE만 허용, category 없을 경우 default는 ALL
    - 입력된 category에 맞는 알림 DTO 리스트를 반환
    - 이외의 값이 들어올 경우 400 응답 (`NotificationCategory.from()` 메서드 확인)
    - 추후 유저, 인증 기능 완성시 인증 정보에서 유저를 가져오는 부분 추가 예정
- 서비스: `NotificationService`
  - `getNotifications`, `getNotificationsByCategory`
    - userId / userId + notificationCategory를 기반으로 알림 탐색
    - 현재는 db에 등록된 모든 알림에 대해 조회하도록 되어 있으며, 조회 범위에 대한 기능 보강 필요

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
1. NOTICE 타입 알림에 대해서
    - NOTICE 타입의 알림은 관리자가 등록하는지?
    - NOTICE 타입 알림을 등록한다면 userId, choreId, choreInstanceId는 null로 들어가는게 맞을까요?
    - ALL 타입 조회시에 userId가 null인 NOTICE와, userId가 설정되어 있는 CHORE 타입을 한번에 조회할 수 있는 쿼리 작성 필요
 
2. 알림 조회 범위는 어떻게 잡아야 할까요?
    - SENT 상태인 알림만 조회하도록 해야 할까요?
    - 페이징 처리 필요 (프론트엔드와 논의 가능)

Closes #9 
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
  - 컨트롤러, 서비스 코드 테스트 작성 
- [ ] API 테스트 
