### PR TITLE
[feat] 알림 읽음 처리 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/homemate/entity/Notification.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notification.java
@@ -66,4 +66,8 @@ public class Notification {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    public void read() {
+        isRead = true;
+        readAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/zerobase/homemate/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/homemate/exception/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     
     // 403 Forbidden
     FORBIDDEN("FORBIDDEN", "권한이 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+
+    // 404 Not Found
+    NOTIFICATION_NOT_FOUND("NOTIFICATION_NOT_FOUND", "해당 알림을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
+++ b/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
@@ -1,10 +1,12 @@
 package com.zerobase.homemate.notification.controller;
 
+import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.entity.enums.NotificationCategory;
 import com.zerobase.homemate.notification.dto.NotificationDto;
 import com.zerobase.homemate.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,9 +23,10 @@ public class NotificationController {
 
     @GetMapping
     public ResponseEntity<List<NotificationDto>> getNotifications(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(name = "category", defaultValue = "ALL") String category
     ) {
-        Long userId = 1L; // TODO: 인증에서 userId 가져오기
+        Long userId = userPrincipal.id(); // TODO: 인증에서 userId 가져오기
 
         if ("ALL".equalsIgnoreCase(category)) {
             List<NotificationDto> result = notificationService.getNotifications(userId);

--- a/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
+++ b/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
@@ -3,14 +3,12 @@ package com.zerobase.homemate.notification.controller;
 import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.entity.enums.NotificationCategory;
 import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.notification.dto.NotificationReadDto;
 import com.zerobase.homemate.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,7 +24,7 @@ public class NotificationController {
             @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(name = "category", defaultValue = "ALL") String category
     ) {
-        Long userId = userPrincipal.id(); // TODO: 인증에서 userId 가져오기
+        Long userId = userPrincipal.id();
 
         if ("ALL".equalsIgnoreCase(category)) {
             List<NotificationDto> result = notificationService.getNotifications(userId);
@@ -36,6 +34,18 @@ public class NotificationController {
 
         NotificationCategory notificationCategory = NotificationCategory.from(category); // 유효하지 않은 카테고리 입력시 여기서 예외 발생
         List<NotificationDto> result = notificationService.getNotificationsByCategory(userId, notificationCategory);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @PatchMapping("/{notificationId}")
+    public ResponseEntity<NotificationReadDto> readNotification(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long notificationId
+    ) {
+        Long userId = userPrincipal.id();
+
+        NotificationReadDto result = notificationService.updateNotificationToRead(userId, notificationId);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/zerobase/homemate/notification/dto/NotificationReadDto.java
+++ b/src/main/java/com/zerobase/homemate/notification/dto/NotificationReadDto.java
@@ -1,0 +1,28 @@
+package com.zerobase.homemate.notification.dto;
+
+import com.zerobase.homemate.entity.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationReadDto {
+
+    private Long id;
+    private Boolean isRead;
+    private LocalDateTime readAt;
+
+    public static NotificationReadDto from(Notification notification) {
+        return NotificationReadDto.builder()
+                .id(notification.getId())
+                .isRead(notification.getIsRead())
+                .readAt(notification.getReadAt())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
+++ b/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
@@ -2,13 +2,17 @@ package com.zerobase.homemate.notification.service;
 
 import com.zerobase.homemate.entity.Notification;
 import com.zerobase.homemate.entity.enums.NotificationCategory;
+import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.notification.dto.NotificationReadDto;
 import com.zerobase.homemate.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.zerobase.homemate.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +32,19 @@ public class NotificationService {
         List<Notification> list = notificationRepository.findAllByUserIdAndNotificationCategory(userId, category);
 
         return list.stream().map(NotificationDto::fromEntity).toList();
+    }
+
+    @Transactional
+    public NotificationReadDto updateNotificationToRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND));
+
+        if (!userId.equals(notification.getUserId())) {
+            throw new CustomException(FORBIDDEN, "해당 알림을 수정할 권한이 없습니다.");
+        }
+
+        notification.read();
+
+        return NotificationReadDto.from(notification);
     }
 }

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -47,7 +47,7 @@ class NotificationControllerTest {
     @MockitoBean
     NotificationService notificationService;
 
-    private List<NotificationDto> notificationDtos = new ArrayList<>();
+    private List<NotificationDto> notificationDtos;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -138,7 +139,9 @@ class NotificationControllerTest {
 
             // when & then
             mockMvc.perform(get("/notifications?category=WRONG"))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.error.code", equalTo("VALIDATION_ERROR")))
+                    .andExpect(jsonPath("$.error.message", equalTo("잘못된 카테고리 입력입니다.")));
 
             verifyNoInteractions(notificationService);
         }

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -1,7 +1,6 @@
 package com.zerobase.homemate.notification.controller;
 
 import com.zerobase.homemate.auth.security.UserPrincipal;
-import com.zerobase.homemate.entity.enums.NotificationStatus;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.GlobalExceptionHandler;
 import com.zerobase.homemate.notification.dto.NotificationDto;
@@ -21,11 +20,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.zerobase.homemate.entity.enums.NotificationCategory.CHORE;
 import static com.zerobase.homemate.entity.enums.NotificationCategory.NOTICE;
+import static com.zerobase.homemate.entity.enums.NotificationStatus.SCHEDULED;
+import static com.zerobase.homemate.entity.enums.NotificationStatus.SENT;
 import static com.zerobase.homemate.exception.ErrorCode.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -62,11 +62,11 @@ class NotificationControllerTest {
         LocalDateTime baseDateTime = LocalDateTime.now().withHour(12).withMinute(0).withSecond(0);
 
         notificationDtos = List.of(
-                new NotificationDto(1L, 1L, 1L, 1L, CHORE, "화장실 청소", "", baseDateTime.plusDays(1), NotificationStatus.SCHEDULED, false, null, null, null),
-                new NotificationDto(2L, 1L, 2L, 2L, CHORE, "쓰레기 버리기", "", baseDateTime.minusDays(1), NotificationStatus.SENT, true, baseDateTime.minusDays(1).plusHours(6), null, null),
-                new NotificationDto(3L, null, null, null, NOTICE, "공지 사항", "", baseDateTime, NotificationStatus.SENT, false, null, null, null),
-                new NotificationDto(4L, 1L, 2L, 3L, CHORE, "쓰레기 버리기", "", baseDateTime.plusDays(3), NotificationStatus.SCHEDULED, false, null, null, null),
-                new NotificationDto(5L, 2L, 3L, 4L, CHORE, "창문 닦기", "", baseDateTime.plusDays(3), NotificationStatus.SCHEDULED, false, null, null, null)
+                new NotificationDto(1L, 1L, 1L, 1L, CHORE, "화장실 청소", "", baseDateTime.plusDays(1), SCHEDULED, false, null, null, null),
+                new NotificationDto(2L, 1L, 2L, 2L, CHORE, "쓰레기 버리기", "", baseDateTime.minusDays(1), SENT, true, baseDateTime.minusDays(1).plusHours(6), null, null),
+                new NotificationDto(3L, null, null, null, NOTICE, "공지 사항", "", baseDateTime, SENT, false, null, null, null),
+                new NotificationDto(4L, 1L, 2L, 3L, CHORE, "쓰레기 버리기", "", baseDateTime.plusDays(3), SCHEDULED, false, null, null, null),
+                new NotificationDto(5L, 2L, 3L, 4L, CHORE, "창문 닦기", "", baseDateTime.plusDays(3), SCHEDULED, false, null, null, null)
         );
     }
 
@@ -79,14 +79,14 @@ class NotificationControllerTest {
         void success_WithNoCategory() throws Exception {
             // given
             Long userId = 1L;
-            when(notificationService.getNotifications(userId)).thenReturn(notificationDtos);
+            List<NotificationDto> allList = notificationDtos.stream().filter(e -> userId.equals(e.getUserId())).toList();
+            when(notificationService.getNotifications(userId)).thenReturn(allList);
 
             // when & then
             mockMvc.perform(get("/notifications"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$", hasSize(notificationDtos.size())))
-                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())))
-                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(NOTICE.toString())));
+                    .andExpect(jsonPath("$", hasSize(allList.size())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())));
         }
 
         @Test
@@ -94,14 +94,14 @@ class NotificationControllerTest {
         void success_WithCategoryAll() throws Exception {
             // given
             Long userId = 1L;
-            when(notificationService.getNotifications(userId)).thenReturn(notificationDtos);
+            List<NotificationDto> allList = notificationDtos.stream().filter(e -> userId.equals(e.getUserId())).toList();
+            when(notificationService.getNotifications(userId)).thenReturn(allList);
 
             // when & then
             mockMvc.perform(get("/notifications?category=ALL"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$", hasSize(notificationDtos.size())))
-                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())))
-                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(NOTICE.toString())));
+                    .andExpect(jsonPath("$", hasSize(allList.size())))
+                    .andExpect(jsonPath("$[*].notificationCategory", hasItem(CHORE.toString())));
         }
 
         @Test
@@ -109,7 +109,7 @@ class NotificationControllerTest {
         void success_WithCategoryChore() throws Exception {
             // given
             Long userId = 1L;
-            List<NotificationDto> choreList = notificationDtos.stream().filter(e -> CHORE.equals(e.getNotificationCategory())).toList();
+            List<NotificationDto> choreList = notificationDtos.stream().filter(e -> userId.equals(e.getUserId()) && CHORE.equals(e.getNotificationCategory())).toList();
             when(notificationService.getNotificationsByCategory(userId, CHORE)).thenReturn(choreList);
 
             // when & then

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -1,5 +1,6 @@
 package com.zerobase.homemate.notification.controller;
 
+import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.entity.enums.NotificationStatus;
 import com.zerobase.homemate.exception.GlobalExceptionHandler;
 import com.zerobase.homemate.notification.dto.NotificationDto;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -43,6 +46,14 @@ class NotificationControllerTest {
 
     @BeforeEach
     void setUp() {
+        // 인증 정보 주입
+        var principal = new UserPrincipal(1L, "tester", "USER");
+        var auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.authorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        // 테스트 데이터 생성
         LocalDateTime baseDateTime = LocalDateTime.now().withHour(12).withMinute(0).withSecond(0);
 
         notificationDtos = List.of(

--- a/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/controller/NotificationControllerTest.java
@@ -2,8 +2,10 @@ package com.zerobase.homemate.notification.controller;
 
 import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.entity.enums.NotificationStatus;
+import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.GlobalExceptionHandler;
 import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.notification.dto.NotificationReadDto;
 import com.zerobase.homemate.notification.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +26,13 @@ import java.util.List;
 
 import static com.zerobase.homemate.entity.enums.NotificationCategory.CHORE;
 import static com.zerobase.homemate.entity.enums.NotificationCategory.NOTICE;
+import static com.zerobase.homemate.exception.ErrorCode.*;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -61,7 +65,8 @@ class NotificationControllerTest {
                 new NotificationDto(1L, 1L, 1L, 1L, CHORE, "화장실 청소", "", baseDateTime.plusDays(1), NotificationStatus.SCHEDULED, false, null, null, null),
                 new NotificationDto(2L, 1L, 2L, 2L, CHORE, "쓰레기 버리기", "", baseDateTime.minusDays(1), NotificationStatus.SENT, true, baseDateTime.minusDays(1).plusHours(6), null, null),
                 new NotificationDto(3L, null, null, null, NOTICE, "공지 사항", "", baseDateTime, NotificationStatus.SENT, false, null, null, null),
-                new NotificationDto(4L, 1L, 2L, 3L, CHORE, "쓰레기 버리기", "", baseDateTime.plusDays(3), NotificationStatus.SCHEDULED, false, null, null, null)
+                new NotificationDto(4L, 1L, 2L, 3L, CHORE, "쓰레기 버리기", "", baseDateTime.plusDays(3), NotificationStatus.SCHEDULED, false, null, null, null),
+                new NotificationDto(5L, 2L, 3L, 4L, CHORE, "창문 닦기", "", baseDateTime.plusDays(3), NotificationStatus.SCHEDULED, false, null, null, null)
         );
     }
 
@@ -133,17 +138,72 @@ class NotificationControllerTest {
 
         @Test
         @DisplayName("?category=WRONG -> 400 Bad Request")
-        void success_WithWrongCategory() throws Exception {
+        void fail_WithWrongCategory() throws Exception {
             // given
             Long userId = 1L;
 
             // when & then
             mockMvc.perform(get("/notifications?category=WRONG"))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.error.code", equalTo("VALIDATION_ERROR")))
-                    .andExpect(jsonPath("$.error.message", equalTo("잘못된 카테고리 입력입니다.")));
+                    .andExpect(jsonPath("$.error.code", equalTo(VALIDATION_ERROR.getCode())))
+                    .andExpect(jsonPath("$.error.message", equalTo("잘못된 카테고리 입력입니다."))); // NotificationCategory.from() 참고
 
             verifyNoInteractions(notificationService);
+        }
+
+        @Nested
+        @DisplayName("PATCH /notifications/{notificationId}")
+        class UpdateNotificationToRead {
+
+            @Test
+            @DisplayName(" -> 200 OK")
+            void success() throws Exception {
+                // given
+                Long userId = 1L;
+                Long notificationId = 1L;
+                NotificationReadDto notificationReadDto = new NotificationReadDto(notificationId, true, LocalDateTime.now().withNano(0));
+                when(notificationService.updateNotificationToRead(userId, notificationId)).thenReturn(notificationReadDto);
+
+                // when & then
+                mockMvc.perform(patch("/notifications/{notificationId}", notificationId).with(csrf()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.id", equalTo(notificationId.intValue())))
+                        .andExpect(jsonPath("$.isRead", equalTo(notificationReadDto.getIsRead())))
+                        .andExpect(jsonPath("$.readAt", equalTo(notificationReadDto.getReadAt().toString())));
+            }
+
+            @Test
+            @DisplayName("(wrong notificationId) -> 404 Not Found")
+            void fail_WithWrongNotificationId() throws Exception {
+                // given
+                Long userId = 1L;
+                Long notificationId = 999L;
+                when(notificationService.updateNotificationToRead(userId, notificationId))
+                        .thenThrow(new CustomException(NOTIFICATION_NOT_FOUND));
+
+                // when & then
+                mockMvc.perform(patch("/notifications/{notificationId}", notificationId).with(csrf()))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.error.code", equalTo(NOTIFICATION_NOT_FOUND.getCode())))
+                        .andExpect(jsonPath("$.error.message", equalTo(NOTIFICATION_NOT_FOUND.getMessage())));
+            }
+
+            @Test
+            @DisplayName("(userId - notificationId not Match) -> 403 Forbidden")
+            void fail_UserIdNotMatchesWithNotificationId() throws Exception {
+                // given
+                Long userId = 1L;
+                Long notificationId = 5L;
+                when(notificationService.updateNotificationToRead(userId, notificationId))
+                        .thenThrow(new CustomException(FORBIDDEN, "해당 알림을 수정할 권한이 없습니다."));
+
+                // when & then
+                mockMvc.perform(patch("/notifications/{notificationId}", notificationId).with(csrf()))
+                        .andExpect(status().isForbidden())
+                        .andExpect(jsonPath("$.error.code", equalTo(FORBIDDEN.getCode())))
+                        .andExpect(jsonPath("$.error.message", equalTo("해당 알림을 수정할 권한이 없습니다.")));
+            }
+
         }
     }
 }

--- a/src/test/java/com/zerobase/homemate/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/notification/service/NotificationServiceTest.java
@@ -1,7 +1,10 @@
 package com.zerobase.homemate.notification.service;
 
 import com.zerobase.homemate.entity.Notification;
+import com.zerobase.homemate.exception.CustomException;
+import com.zerobase.homemate.exception.ErrorCode;
 import com.zerobase.homemate.notification.dto.NotificationDto;
+import com.zerobase.homemate.notification.dto.NotificationReadDto;
 import com.zerobase.homemate.repository.NotificationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,13 +14,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.zerobase.homemate.entity.enums.NotificationCategory.CHORE;
+import static com.zerobase.homemate.entity.enums.NotificationCategory.NOTICE;
 import static com.zerobase.homemate.entity.enums.NotificationStatus.SCHEDULED;
 import static com.zerobase.homemate.entity.enums.NotificationStatus.SENT;
+import static com.zerobase.homemate.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 
@@ -30,39 +36,20 @@ class NotificationServiceTest {
     @InjectMocks
     private NotificationService notificationService;
 
-    private List<Notification> notifications = new ArrayList<>();
+    private List<Notification> notifications;
 
     @BeforeEach
     void setUp() {
+        // 테스트 데이터 생성
         LocalDateTime baseDateTime = LocalDateTime.now().withHour(12).withMinute(0).withSecond(0);
 
-        Notification notification1 = Notification.builder()
-                .id(1L)
-                .userId(1L)
-                .choreId(1L)
-                .choreInstanceId(1L)
-                .notificationCategory(CHORE)
-                .title("화장실 청소")
-                .scheduledAt(baseDateTime.plusDays(1))
-                .notificationStatus(SCHEDULED)
-                .isRead(false)
-                .readAt(null)
-                .build();
-
-        Notification notification2 = Notification.builder()
-                .id(2L)
-                .userId(1L)
-                .choreId(2L)
-                .choreInstanceId(2L)
-                .notificationCategory(CHORE)
-                .title("쓰레기 버리기")
-                .scheduledAt(baseDateTime.minusDays(1))
-                .notificationStatus(SENT)
-                .isRead(true)
-                .readAt(baseDateTime.minusDays(1).plusHours(1))
-                .build();
-
-        notifications.addAll(List.of(notification1, notification2));
+        notifications = List.of(
+                new Notification(1L, 1L, 1L, 1L, CHORE, "화장실 청소", "", baseDateTime.plusDays(1), SCHEDULED, false, null, null, null),
+                new Notification(2L, 1L, 2L, 2L, CHORE, "쓰레기 버리기", "", baseDateTime.minusDays(1), SENT, true, baseDateTime.minusDays(1).plusHours(6), null, null),
+                new Notification(3L, null, null, null, NOTICE, "공지 사항", "", baseDateTime, SENT, false, null, null, null),
+                new Notification(4L, 1L, 2L, 3L, CHORE, "쓰레기 버리기", "", baseDateTime.plusDays(3), SCHEDULED, false, null, null, null),
+                new Notification(5L, 2L, 3L, 4L, CHORE, "창문 닦기", "", baseDateTime.plusDays(3), SCHEDULED, false, null, null, null)
+        );
     }
 
     @Test
@@ -70,7 +57,7 @@ class NotificationServiceTest {
         // given
         Long userId = 1L;
 
-        List<Notification> list = notifications.stream().filter(e -> e.getUserId().equals(userId)).toList();
+        List<Notification> list = notifications.stream().filter(e -> userId.equals(e.getUserId())).toList();
         when(notificationRepository.findAllByUserId(userId)).thenReturn(list);
 
         // when
@@ -95,5 +82,52 @@ class NotificationServiceTest {
 
         // then
         assertThat(result.size()).isEqualTo(choreList.size());
+    }
+
+    @Test
+    void updateNotificationToRead_Success() {
+        // given
+        Long userId = 1L;
+        Long notificationId = 1L;
+
+        Notification notification = notifications.stream().filter(e -> notificationId.equals(e.getId())).findFirst().get();
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+        // when
+        NotificationReadDto result = notificationService.updateNotificationToRead(userId, notificationId);
+
+        // then
+        assertThat(result.getId()).isEqualTo(notificationId);
+        assertThat(result.getIsRead()).isTrue();
+        assertThat(result.getReadAt()).isNotNull();
+    }
+
+    @Test
+    void updateNotificationToRead_ThrowsException_WhenNotificationNotFound() {
+        // given
+        Long userId = 1L;
+        Long notificationId = 999L;
+
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.empty());
+
+        // when && then
+        assertThatThrownBy(() -> notificationService.updateNotificationToRead(userId, notificationId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(NOTIFICATION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void updateNotificationToRead_ThrowsException_WhenUserIdNotMatched() {
+        // given
+        Long userId = 999L;
+        Long notificationId = 1L;
+
+        Notification notification = notifications.stream().filter(e -> notificationId.equals(e.getId())).findFirst().get();
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+        // when && then
+        assertThatThrownBy(() -> notificationService.updateNotificationToRead(userId, notificationId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("해당 알림을 수정할 권한이 없습니다.");
     }
 }


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

-
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- 사용자 인증 정보를 가져오는 부분 도입
- 알림 읽음 처리를 위한 기초 기능 구현

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

- 컨트롤러에 `UserPrincipal` 도입하여 사용자 인증 정보를 가져옴
- `NotificationController`
  - `readNotification`: 알림 읽음 처리 메서드
    - `PATCH /notifications/{notificationId}` -> `200 OK` 응답
    - `NotificationReadDto`를 통해 수정된 부분만 간략화하여 전달
    - `notificationId`가 유효하지 않으면 400 응답, 본인의 알림이 아닌 경우 403 응답
- `NotificationService`
  - `updateNotificationToRead`
    - 유효한 `notificationId`인지, 해당 알림이 본인의 알림인지 검사
    - 현재 구조는 `CHORE` 타입만 수정할 수 있으며 `NOTICE` 타입에 대해서는 개선 필요
- `Notification`
  - setter 대신 `read()` 메서드를 통해 변경 의도를 명확히 하고 관련 변경점이 한번에 변경되도록 기능 제공


## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
- 알림 테이블 구조 변경이 필요할 듯 하여 고민중입니다. 관련 내용 정리해서 올리겠습니다.

## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
  - 컨트롤러, 서비스 테스트 코드 작성
- [ ] API 테스트 