### PR TITLE
Feature/hyunjae kwon#3

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -28,14 +28,14 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/update/{choreId}")
+    @PutMapping("/update/{choreInstanceId}")
     public ResponseEntity<ChoreDto.Response> updateChore(
         @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable Long choreId,
+        @PathVariable Long choreInstanceId,
         @Valid @RequestBody ChoreDto.UpdateRequest request) {
 
         ChoreDto.Response response = choreService.updateChores(user.id(),
-         choreId, request);
+            choreInstanceId, request);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -1,12 +1,13 @@
 package com.zerobase.homemate.chore.controller;
 
+import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.chore.service.ChoreService;
-import com.zerobase.homemate.util.JwtUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,16 +16,27 @@ import org.springframework.web.bind.annotation.*;
 public class ChoreController {
 
     private final ChoreService choreService;
-    private final JwtUtil jwtUtil;
 
     @PostMapping("/create")
     public ResponseEntity<ChoreDto.Response> createChore(
-            @RequestHeader("Authorization") String authorization,
-            @Valid @RequestBody ChoreDto.CreateRequest request) {
+        @AuthenticationPrincipal UserPrincipal user,
+        @Valid @RequestBody ChoreDto.CreateRequest request) {
 
-        Long userId = jwtUtil.extractUserIdFromToken(authorization);
-        ChoreDto.Response response = choreService.createChores(userId, request);
+        ChoreDto.Response response = choreService.createChores(user.id(),
+            request);
         
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/update/{choreId}")
+    public ResponseEntity<ChoreDto.Response> updateChore(
+        @AuthenticationPrincipal UserPrincipal user,
+        @PathVariable Long choreId,
+        @Valid @RequestBody ChoreDto.UpdateRequest request) {
+
+        ChoreDto.Response response = choreService.updateChores(user.id(),
+         choreId, request);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
+++ b/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
@@ -62,6 +62,7 @@ public class ChoreDto {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;
+        private Long version;
 
         public static Response fromEntity(Chore chore) {
             return Response.builder()
@@ -78,6 +79,7 @@ public class ChoreDto {
                 .createdAt(chore.getCreatedAt())
                 .updatedAt(chore.getUpdatedAt())
                 .deletedAt(chore.getDeletedAt())
+                .version(chore.getVersion())
                 .build();
         }
     }

--- a/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
+++ b/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
@@ -114,4 +114,9 @@ public class ChoreDto {
                 .build();
         }
     }
+
+    public static boolean isValidDateRange(
+        LocalDate startDate, LocalDate endDate) {
+        return startDate == null || endDate == null || !startDate.isAfter(endDate);
+    }
 }

--- a/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
+++ b/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.homemate.chore.dto;
 
 import com.zerobase.homemate.entity.Chore;
+import com.zerobase.homemate.entity.enums.RepeatType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
@@ -29,10 +30,11 @@ public class ChoreDto {
 
         private LocalTime notificationTime;
 
+        @NotNull(message = "공간 입력은 필수입니다")
         private String space;
 
         @NotNull(message = "반복 타입은 필수입니다")
-        private Chore.RepeatType repeatType;
+        private RepeatType repeatType;
 
         private Integer repeatInterval;
 
@@ -48,13 +50,44 @@ public class ChoreDto {
     @Builder
     @Getter
     @Setter
+    public static class UpdateRequest {
+        @NotBlank(message = "집안일 제목은 필수입니다")
+        private String title;
+
+        @NotNull(message = "알림 여부는 필수입니다")
+        private Boolean notificationYn;
+
+        private LocalTime notificationTime;
+
+        @NotNull(message = "공간 입력은 필수입니다")
+        private String space;
+
+        @NotNull(message = "반복 타입은 필수입니다")
+        private RepeatType repeatType;
+
+        private Integer repeatInterval;
+
+        @NotNull(message = "시작 일자는 필수입니다")
+        private LocalDate startDate;
+
+        @NotNull(message = "종료 일자는 필수입니다")
+        private LocalDate endDate;
+
+        private Boolean applyToFuture;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    @Getter
+    @Setter
     public static class Response {
         private Long id;
         private String title;
         private Boolean notificationYn;
         private LocalTime notificationTime;
         private String space;
-        private Chore.RepeatType repeatType;
+        private RepeatType repeatType;
         private Integer repeatInterval;
         private LocalDate startDate;
         private LocalDate endDate;
@@ -62,7 +95,6 @@ public class ChoreDto {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;
-        private Long version;
 
         public static Response fromEntity(Chore chore) {
             return Response.builder()
@@ -79,7 +111,6 @@ public class ChoreDto {
                 .createdAt(chore.getCreatedAt())
                 .updatedAt(chore.getUpdatedAt())
                 .deletedAt(chore.getDeletedAt())
-                .version(chore.getVersion())
                 .build();
         }
     }

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -155,9 +155,8 @@ public class ChoreService {
                     choreInstance.getDueDate(),
                     ChoreStatus.PENDING
                 );
-            futureInstances.forEach(instance -> {
-               instance.setChoreStatus(ChoreStatus.CANCELLED);
-            });
+            futureInstances.forEach(instance ->
+                instance.setChoreStatus(ChoreStatus.CANCELLED));
             choreInstanceRepository.saveAll(futureInstances);
             choreInstanceRepository.flush();
         } else {

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -3,11 +3,13 @@ package com.zerobase.homemate.chore.service;
 import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
+import com.zerobase.homemate.entity.enums.ChoreStatus;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.ErrorCode;
 import com.zerobase.homemate.repository.ChoreRepository;
 import com.zerobase.homemate.repository.ChoreInstanceRepository;
 import com.zerobase.homemate.util.ChoreInstanceGenerator;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,8 +29,12 @@ public class ChoreService {
     public ChoreDto.Response createChores(Long userId,
         ChoreDto.CreateRequest request) {
 
-        if (request.getNotificationYn() && request.getNotificationTime() == null) {
+        if (request.getNotificationYn()
+            && request.getNotificationTime() == null) {
             throw new CustomException(ErrorCode.VALIDATION_ERROR);
+        } else if (ChoreDto.isValidDateRange(request.getStartDate(),
+            request.getEndDate())) {
+            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
         }
 
         Chore chore = Chore.builder()
@@ -50,5 +56,120 @@ public class ChoreService {
         choreInstanceRepository.saveAll(instances);
 
         return ChoreDto.Response.fromEntity(savedChore);
+    }
+
+    @Transactional
+    public ChoreDto.Response updateChores(Long userId, Long choreInstanceId,
+        ChoreDto.UpdateRequest request) {
+
+        ChoreInstance choreInstance =
+            choreInstanceRepository.findById(choreInstanceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHORE_NOT_FOUND)) ;
+        Chore chore = choreRepository.findById(choreInstance.getChoreId())
+            .orElseThrow(() -> new CustomException(ErrorCode.CHORE_NOT_FOUND));
+
+        if (!chore.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        } else if (request.getNotificationYn()
+            && request.getNotificationTime() == null) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+        } else if (ChoreDto.isValidDateRange(request.getStartDate(),
+            request.getEndDate())) {
+            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
+        }
+
+        boolean isRepeatChanged =
+            !Objects.equals(chore.getRepeatType(), request.getRepeatType()) ||
+                !Objects.equals(chore.getRepeatInterval(),
+                    request.getRepeatInterval());
+        boolean startDateChanged =
+            !chore.getStartDate().equals(request.getStartDate());
+        boolean endDateChanged =
+            !chore.getEndDate().equals(request.getEndDate());
+
+        if (isRepeatChanged || startDateChanged || endDateChanged) {
+            return updateChoreInstance(chore, choreInstance, request);
+        } else {
+            return updateChoreOnly(chore, choreInstance, request);
+        }
+    }
+
+    private ChoreDto.Response updateChoreOnly(Chore chore,
+        ChoreInstance choreInstance, ChoreDto.UpdateRequest request) {
+
+        chore.setTitle(request.getTitle());
+        chore.setNotificationYn(request.getNotificationYn());
+        chore.setSpace(request.getSpace());
+
+        if (!request.getNotificationYn()) {
+            chore.setNotificationTime(null);
+        } else {
+            chore.setNotificationTime(request.getNotificationTime());
+        }
+
+        List<ChoreInstance> futureInstances = choreInstanceRepository
+            .findByChoreIdAndDueDateGreaterThanEqualAndChoreStatus(
+                chore.getId(),
+                choreInstance.getDueDate(),
+                ChoreStatus.PENDING
+            );
+
+        // TODO : 벌크 업데이트 JPQL 사용 전환
+        futureInstances.forEach(instance -> {
+                instance.setTitleSnapshot(request.getTitle());
+                instance.setNotificationTime(
+                    request.getNotificationYn() ? request.getNotificationTime() : null);
+            }
+        );
+
+        choreInstanceRepository.saveAll(futureInstances);
+        Chore updatedChore = choreRepository.save(chore);
+
+        return ChoreDto.Response.fromEntity(updatedChore);
+    }
+
+    private ChoreDto.Response updateChoreInstance(Chore chore,
+        ChoreInstance choreInstance, ChoreDto.UpdateRequest request) {
+
+        Chore newChore = Chore.builder()
+            .userId(chore.getUserId())
+            .title(request.getTitle())
+            .notificationYn(request.getNotificationYn())
+            .notificationTime(request.getNotificationTime())
+            .space(request.getSpace())
+            .repeatType(request.getRepeatType())
+            .repeatInterval(request.getRepeatInterval())
+            .startDate(request.getStartDate())
+            .endDate(request.getEndDate())
+            .isDeleted(false)
+            .build();
+
+        Chore savedNewChore = choreRepository.save(newChore);
+        choreRepository.flush();
+
+        // TODO : 벌크 업데이트 JPQL 사용 전환
+        if (request.getApplyToFuture()) {
+            List<ChoreInstance> futureInstances = choreInstanceRepository
+                .findByChoreIdAndDueDateGreaterThanEqualAndChoreStatus(
+                    chore.getId(),
+                    choreInstance.getDueDate(),
+                    ChoreStatus.PENDING
+                );
+            futureInstances.forEach(instance -> {
+               instance.setChoreStatus(ChoreStatus.CANCELLED);
+            });
+            choreInstanceRepository.saveAll(futureInstances);
+            choreInstanceRepository.flush();
+        } else {
+            choreInstance.setChoreStatus(ChoreStatus.CANCELLED);
+            choreInstanceRepository.save(choreInstance);
+            choreInstanceRepository.flush();
+        }
+
+        List<ChoreInstance> newInstances =
+            choreInstanceGenerator.generateInstances(savedNewChore);
+        choreInstanceRepository.saveAll(newInstances);
+
+        return ChoreDto.Response.fromEntity(savedNewChore);
     }
 }

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -3,6 +3,8 @@ package com.zerobase.homemate.chore.service;
 import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
+import com.zerobase.homemate.exception.CustomException;
+import com.zerobase.homemate.exception.ErrorCode;
 import com.zerobase.homemate.repository.ChoreRepository;
 import com.zerobase.homemate.repository.ChoreInstanceRepository;
 import com.zerobase.homemate.util.ChoreInstanceGenerator;
@@ -24,6 +26,10 @@ public class ChoreService {
     @Transactional
     public ChoreDto.Response createChores(Long userId,
         ChoreDto.CreateRequest request) {
+
+        if (request.getNotificationYn() && request.getNotificationTime() == null) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR);
+        }
 
         Chore chore = Chore.builder()
             .userId(userId)

--- a/src/main/java/com/zerobase/homemate/config/SecurityConfig.java
+++ b/src/main/java/com/zerobase/homemate/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
         .csrf(csrf -> csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/auth/**", "/policies/**").permitAll()
+            .requestMatchers("/auth/**", "/policies/**", "/chore/**").permitAll()
             .anyRequest().authenticated()
         )
 //        .exceptionHandling() 예외처리 추가 예정

--- a/src/main/java/com/zerobase/homemate/entity/Chore.java
+++ b/src/main/java/com/zerobase/homemate/entity/Chore.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,6 +19,7 @@ import java.util.List;
 @Entity
 @Table(name = "chore")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -38,7 +40,7 @@ public class Chore {
     @Column(name = "notification_yn", nullable = false)
     private Boolean notificationYn;
 
-    @Column(name = "notification_time", nullable = false)
+    @Column(name = "notification_time")
     private LocalTime notificationTime;
 
     @Column(name = "space", length = 10)
@@ -71,6 +73,10 @@ public class Chore {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
 
     // Users 테이블 완성되면 추가
     /* @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/zerobase/homemate/entity/Chore.java
+++ b/src/main/java/com/zerobase/homemate/entity/Chore.java
@@ -1,5 +1,6 @@
 package com.zerobase.homemate.entity;
 
+import com.zerobase.homemate.entity.enums.RepeatType;
 import jakarta.persistence.*;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
@@ -74,10 +75,6 @@ public class Chore {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    @Version
-    @Column(name = "version")
-    private Long version;
-
     // Users 테이블 완성되면 추가
     /* @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
@@ -87,8 +84,4 @@ public class Chore {
     @OneToMany(mappedBy = "chore", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<ChoreInstance> choreInstances = new ArrayList<>();
-
-    public enum RepeatType {
-        NONE, DAILY, WEEKLY, MONTHLY, YEARLY
-    }
 }

--- a/src/main/java/com/zerobase/homemate/entity/Chore.java
+++ b/src/main/java/com/zerobase/homemate/entity/Chore.java
@@ -44,7 +44,7 @@ public class Chore {
     @Column(name = "notification_time")
     private LocalTime notificationTime;
 
-    @Column(name = "space", length = 10)
+    @Column(name = "space", length = 10, nullable = false)
     private String space;
 
     @Enumerated(EnumType.STRING)
@@ -75,11 +75,9 @@ public class Chore {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    // Users 테이블 완성되면 추가
-    /* @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", insertable = false, updatable = false)
-    private Users user;
-    */
+    private User user;
 
     @OneToMany(mappedBy = "chore", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default

--- a/src/main/java/com/zerobase/homemate/entity/ChoreInstance.java
+++ b/src/main/java/com/zerobase/homemate/entity/ChoreInstance.java
@@ -1,11 +1,13 @@
 package com.zerobase.homemate.entity;
 
+import com.zerobase.homemate.entity.enums.ChoreStatus;
 import jakarta.persistence.*;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,6 +18,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "chore_instance")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -55,14 +58,7 @@ public class ChoreInstance {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @Column(name = "source_version")
-    private Long sourceVersion;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chore_id", insertable = false, updatable = false)
     private Chore chore;
-
-    public enum ChoreStatus {
-        PENDING, COMPLETED, CANCELLED
-    }
 }

--- a/src/main/java/com/zerobase/homemate/entity/ChoreInstance.java
+++ b/src/main/java/com/zerobase/homemate/entity/ChoreInstance.java
@@ -1,6 +1,7 @@
 package com.zerobase.homemate.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,8 +30,14 @@ public class ChoreInstance {
     @Column(name = "chore_id", nullable = false)
     private Long choreId;
 
+    @Column(name = "title_snapshot", nullable = false)
+    private String titleSnapshot;
+
     @Column(name = "due_date", nullable = false)
     private LocalDate dueDate;
+
+    @Column(name = "notification_time")
+    private LocalTime notificationTime;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "chore_status", nullable = false)
@@ -48,11 +55,14 @@ public class ChoreInstance {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "source_version")
+    private Long sourceVersion;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chore_id", insertable = false, updatable = false)
     private Chore chore;
 
     public enum ChoreStatus {
-        PENDING, COMPLETED
+        PENDING, COMPLETED, CANCELLED
     }
 }

--- a/src/main/java/com/zerobase/homemate/entity/enums/ChoreStatus.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/ChoreStatus.java
@@ -1,0 +1,5 @@
+package com.zerobase.homemate.entity.enums;
+
+public enum ChoreStatus {
+    PENDING, COMPLETED, CANCELLED
+}

--- a/src/main/java/com/zerobase/homemate/entity/enums/RepeatType.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/RepeatType.java
@@ -1,0 +1,5 @@
+package com.zerobase.homemate.entity.enums;
+
+public enum RepeatType {
+    NONE, DAILY, WEEKLY, MONTHLY, YEARLY
+}

--- a/src/main/java/com/zerobase/homemate/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/homemate/exception/ErrorCode.java
@@ -18,9 +18,10 @@ public enum ErrorCode {
     UNAUTHORIZED("UNAUTHORIZED", "인증된 토큰 값이 아닙니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_EXPIRED("TOKEN_EXPIRED", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_NOT_FOUND("TOKEN_NOT_FOUND", "토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    
+
     // 403 Forbidden
     FORBIDDEN("FORBIDDEN", "권한이 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    CHORE_NOT_FOUND("CHORE_NOT_FOUND", "해당 집안일을 찾을 수 없습니다", HttpStatus.FORBIDDEN),
     
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
@@ -1,10 +1,19 @@
 package com.zerobase.homemate.repository;
 
 import com.zerobase.homemate.entity.ChoreInstance;
+import com.zerobase.homemate.entity.enums.ChoreStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface ChoreInstanceRepository extends JpaRepository<ChoreInstance, Long> {
     
+    List<ChoreInstance> findByChoreIdAndDueDateGreaterThanEqualAndChoreStatus(
+        Long choreId, 
+        LocalDate dueDate, 
+        ChoreStatus choreStatus
+    );
 }

--- a/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
+++ b/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
@@ -42,10 +42,13 @@ public class ChoreInstanceGenerator {
 
     private ChoreInstance createInstance(Chore chore, LocalDate dueDate) {
         return ChoreInstance.builder()
-                .choreId(chore.getId())
-                .dueDate(dueDate)
-                .choreStatus(ChoreInstance.ChoreStatus.PENDING)
-                .build();
+            .choreId(chore.getId())
+            .titleSnapshot(chore.getTitle())
+            .dueDate(dueDate)
+            .notificationTime(chore.getNotificationTime())
+            .choreStatus(ChoreInstance.ChoreStatus.PENDING)
+            .sourceVersion(chore.getVersion())
+            .build();
     }
 
     private LocalDate getNextDate(LocalDate currentDate,

--- a/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
+++ b/src/main/java/com/zerobase/homemate/util/ChoreInstanceGenerator.java
@@ -2,6 +2,8 @@ package com.zerobase.homemate.util;
 
 import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
+import com.zerobase.homemate.entity.enums.ChoreStatus;
+import com.zerobase.homemate.entity.enums.RepeatType;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.ErrorCode;
 import org.springframework.stereotype.Component;
@@ -18,7 +20,7 @@ public class ChoreInstanceGenerator {
     public List<ChoreInstance> generateInstances(Chore chore) {
         List<ChoreInstance> instances = new ArrayList<>();
 
-        if (chore.getRepeatType() == Chore.RepeatType.NONE) {
+        if (chore.getRepeatType() == RepeatType.NONE) {
             instances.add(createInstance(chore, chore.getStartDate()));
         } else {
             LocalDate currentDate = chore.getStartDate();
@@ -46,13 +48,12 @@ public class ChoreInstanceGenerator {
             .titleSnapshot(chore.getTitle())
             .dueDate(dueDate)
             .notificationTime(chore.getNotificationTime())
-            .choreStatus(ChoreInstance.ChoreStatus.PENDING)
-            .sourceVersion(chore.getVersion())
+            .choreStatus(ChoreStatus.PENDING)
             .build();
     }
 
     private LocalDate getNextDate(LocalDate currentDate,
-        Chore.RepeatType repeatType, Integer repeatInterval) {
+        RepeatType repeatType, Integer repeatInterval) {
         return switch (repeatType) {
             case DAILY -> currentDate.plusDays(repeatInterval);
             case WEEKLY -> currentDate.plusWeeks(repeatInterval);


### PR DESCRIPTION
## 📝 계획
### 변경 전 상태
- 인스턴스 생성 시 집안일 이름과 알림 시간 미저장

### 변경 후 상태
- ENUM 타입 분리
- 유저 정보 SecurityContext 에서 추출
- 집안일 생성 시 알림 여부와 알림 시간의 유효성 검증 추가
- 인스턴스 생성 시 집안일 이름과 알림 시간 저장 (집안일 수정 시 과거 이름이 안 보이는 현상 방지 및 알림 시간 연동)
- 집안일 수정

## 💡PR에서 핵심적으로 변경된 사항
- 집안일 수정의 시나리오 별 서비스 로직 구분
- 반복 주기, 시작일, 종료일 변경 시 이 일정만 변경/모든 일정 변경 여부에 따라 나눠짐
- 이 일정만 변경 시 집안일 자체 재생성, 해당 인스턴스만 ```CANCELLED```
- 모든 일정 변경 시 과거 내역은 보관하고, 추후 일정 전부 ```CANCELLED``` 후 인스턴스 재생성

## 📢이외 추가 변경 부분 및 기타
- 알림 시간을 인스턴스마다 넣는 방식으로 변경했는데 알림 발송 조건에 따라 추후 제거해도 되는 컬럼입니다.
- 대량 인스턴스 ```UPDATE``` 는 추후 JPQL 로 변경하여 성능 향상 계획입니다.
- 초기 인스턴스 생성 시에도 한꺼번에 많은 데이터를 ```save``` 하는 방법을 제외하고 서치 중입니다. 혹시 의견 있으시면 알려주시면 감사드리겠습니다.

## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 

- 반복 주기, 시작일, 종료일을 제외한 값을 수정한 경우
<img width="1282" height="720" alt="image" src="https://github.com/user-attachments/assets/52c17a23-d7cf-46f9-86c1-a3b0b2f21c4f" />

- 집안일 데이터, 인스턴스 값 수정
<img width="1226" height="19" alt="image" src="https://github.com/user-attachments/assets/ad21c9bd-a92a-4a2a-bcfe-5ace26817884" />
<img width="867" height="424" alt="image" src="https://github.com/user-attachments/assets/8b8a9aeb-92cb-430c-ac1b-5512756bf477" />

- 반복 주기를 수정한 경우
<img width="1281" height="718" alt="image" src="https://github.com/user-attachments/assets/3f7e4fe4-204e-4426-aef0-810177834185" />

- 새로운 집안일 생성, 기존 인스턴스 값 ```CANCELLED```, 신규 인스턴스 생성
<img width="1227" height="36" alt="image" src="https://github.com/user-attachments/assets/b2333439-f292-43d3-a01a-e3302ff76824" />

<img width="857" height="422" alt="image" src="https://github.com/user-attachments/assets/5c2b01a9-e11c-4d1c-a137-071b85e1e55a" />

<img width="867" height="391" alt="image" src="https://github.com/user-attachments/assets/f090886b-4f2e-4afc-8ae7-f85a3a7c0d5d" />

- 예외 상황 발생 시
<img width="1278" height="636" alt="image" src="https://github.com/user-attachments/assets/865d708b-82a0-4df7-81ec-09624b7f2023" />

<img width="1277" height="637" alt="image" src="https://github.com/user-attachments/assets/1b868def-e6c7-48b4-8be4-2ef2096793da" />
