### PR TITLE
[feat] #34 - 공지 알림 리스트 조회 기능

### DIFF
--- a/src/main/java/com/zerobase/homemate/entity/Notice.java
+++ b/src/main/java/com/zerobase/homemate/entity/Notice.java
@@ -1,0 +1,41 @@
+package com.zerobase.homemate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "message", columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "scheduled_at", nullable = false)
+    private LocalDateTime scheduledAt;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
+++ b/src/main/java/com/zerobase/homemate/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.zerobase.homemate.notification.controller;
 
 import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.notification.dto.ChoreNotificationDto;
+import com.zerobase.homemate.notification.dto.NoticeDto;
 import com.zerobase.homemate.notification.dto.NotificationReadDto;
 import com.zerobase.homemate.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,17 @@ public class NotificationController {
         Long userId = userPrincipal.id();
 
         NotificationReadDto result = notificationService.updateChoreNotificationToRead(userId, notificationId);
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/notices")
+    public ResponseEntity<List<NoticeDto>> getNotices(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        Long userId = userPrincipal.id();
+
+        List<NoticeDto> result = notificationService.getNotices(userId);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/zerobase/homemate/notification/dto/NoticeDto.java
+++ b/src/main/java/com/zerobase/homemate/notification/dto/NoticeDto.java
@@ -1,0 +1,35 @@
+package com.zerobase.homemate.notification.dto;
+
+import com.zerobase.homemate.entity.Notice;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeDto {
+
+    private Long id;
+    private String title;
+    private String message;
+    private LocalDateTime scheduledAt;
+    // TODO: NoticeRead 추가 후 필드 추가 예정
+    // private Boolean isRead;
+    // private LocalDateTime readAt;
+    private LocalDateTime createdAt;
+
+    public static NoticeDto fromEntity(Notice notice) {
+        return NoticeDto.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .message(notice.getMessage())
+                .scheduledAt(notice.getScheduledAt())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
+++ b/src/main/java/com/zerobase/homemate/notification/service/NotificationService.java
@@ -1,10 +1,13 @@
 package com.zerobase.homemate.notification.service;
 
 import com.zerobase.homemate.entity.ChoreNotification;
+import com.zerobase.homemate.entity.Notice;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.notification.dto.ChoreNotificationDto;
+import com.zerobase.homemate.notification.dto.NoticeDto;
 import com.zerobase.homemate.notification.dto.NotificationReadDto;
 import com.zerobase.homemate.repository.ChoreNotificationRepository;
+import com.zerobase.homemate.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,6 +26,7 @@ import static com.zerobase.homemate.exception.ErrorCode.NOTIFICATION_NOT_FOUND;
 public class NotificationService {
 
     private final ChoreNotificationRepository choreNotificationRepository;
+    private final NoticeRepository noticeRepository;
 
     private static final int MAX_NOTIFICATION_SIZE = 30;
 
@@ -31,7 +35,7 @@ public class NotificationService {
         Pageable pageable = PageRequest.of(
                 0,
                 MAX_NOTIFICATION_SIZE,
-                Sort.by(Sort.Order.desc("createdAt"))
+                Sort.by(Sort.Order.desc("scheduledAt"))
         );
         List<ChoreNotification> list = choreNotificationRepository.findByUserIdAndIsCancelledFalseAndScheduledAtBefore(
                 userId,
@@ -54,5 +58,18 @@ public class NotificationService {
         notification.read();
 
         return NotificationReadDto.fromChoreNotification(notification);
+    }
+
+    @Transactional(readOnly = true)
+    public List<NoticeDto> getNotices(Long userId) { // userId는 NoticeRead 추가 후 사용 예정
+        Pageable pageable = PageRequest.of(
+                0,
+                MAX_NOTIFICATION_SIZE,
+                Sort.by(Sort.Order.desc("scheduledAt"))
+        );
+
+        List<Notice> list = noticeRepository.findByScheduledAtBefore(LocalDateTime.now(), pageable);
+
+        return list.stream().map(NoticeDto::fromEntity).toList();
     }
 }

--- a/src/main/java/com/zerobase/homemate/repository/NoticeRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/NoticeRepository.java
@@ -1,0 +1,15 @@
+package com.zerobase.homemate.repository;
+
+import com.zerobase.homemate.entity.Notice;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findByScheduledAtBefore(LocalDateTime scheduledAt, Pageable pageable);
+}


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

-
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- Notice 테이블 추가
- 공지 알림 리스트 조회 기능 기초 구현

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

- `Notice` 엔티티, `NoticeDto` 추가
  - `NoticeDto`에 알림 읽음 관련 필드(`isRead`, `readAt`)은 알림 읽음 기능 구현시 추가 예정
- `NotificationController`: `getNotices` 추가
- `NotificationService`: `getNotices` 추가
  - `userId` 파라미터는 추후 알림 읽음 기능 구현시에 사용 예정
  - 추후 알림 읽음 여부를 기록하는 테이블과 조인하는 과정 필요

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
- 알림 읽음 여부 관련 내용은 다음 pr (이슈 #35)에서 추가할 예정입니다. 
- 테스트 코드는 마찬가지로 다음 pr에 추가할 예정입니다.

Close #34 
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 