### PR TITLE
[bug, refeactor] 공간별 집안일 조회 기능 수정

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
+++ b/src/main/java/com/zerobase/homemate/chore/dto/ChoreDto.java
@@ -72,7 +72,8 @@ public class ChoreDto {
         private String title;
         private Boolean notificationYn;
         private LocalTime notificationTime;
-        private Space space;
+        private Long spaceChoreId;
+        private String spaceChoreName;
         private RepeatType repeatType;
         private Integer repeatInterval;
         private LocalDate startDate;
@@ -88,7 +89,8 @@ public class ChoreDto {
                 .title(chore.getTitle())
                 .notificationYn(chore.getNotificationYn())
                 .notificationTime(chore.getNotificationTime())
-                .space(chore.getSpace())
+                .spaceChoreId(chore.getSpaceChore().getId())
+                .spaceChoreName(chore.getSpaceChore().getTitleKo())
                 .repeatType(chore.getRepeatType())
                 .repeatInterval(chore.getRepeatInterval())
                 .startDate(chore.getStartDate())

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -4,12 +4,14 @@ import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.chore.dto.ChoreInstanceDto;
 import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
+import com.zerobase.homemate.entity.SpaceChore;
 import com.zerobase.homemate.entity.User;
 import com.zerobase.homemate.entity.enums.ChoreStatus;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.ErrorCode;
 import com.zerobase.homemate.repository.ChoreRepository;
 import com.zerobase.homemate.repository.ChoreInstanceRepository;
+import com.zerobase.homemate.repository.SpaceChoreRepository;
 import com.zerobase.homemate.repository.UserRepository;
 import com.zerobase.homemate.util.ChoreInstanceGenerator;
 import java.time.LocalDate;
@@ -30,6 +32,7 @@ public class ChoreService {
     private final ChoreInstanceRepository choreInstanceRepository;
     private final ChoreInstanceGenerator choreInstanceGenerator;
     private final UserRepository userRepository;
+    private final SpaceChoreRepository spaceChoreRepository;
 
     @Transactional
     public ChoreDto.Response createChores(Long userId,
@@ -46,12 +49,15 @@ public class ChoreService {
 
         User userReference = userRepository.getReferenceById(userId);
 
+        SpaceChore spaceChore = spaceChoreRepository.findBySpace(request.getSpace())
+                .orElseThrow( () -> new CustomException(ErrorCode.SPACE_NOT_FOUND));
+
         Chore chore = Chore.builder()
             .user(userReference)
             .title(request.getTitle())
             .notificationYn(request.getNotificationYn())
             .notificationTime(request.getNotificationTime())
-            .space(request.getSpace())
+            .spaceChore(spaceChore)
             .repeatType(request.getRepeatType())
             .repeatInterval(request.getRepeatInterval())
             .startDate(request.getStartDate())
@@ -158,7 +164,10 @@ public class ChoreService {
 
         chore.setTitle(request.getTitle());
         chore.setNotificationYn(request.getNotificationYn());
-        chore.setSpace(request.getSpace());
+
+        SpaceChore spaceChore = spaceChoreRepository.findBySpace(request.getSpace())
+                .orElseThrow(() -> new CustomException(ErrorCode.SPACE_NOT_FOUND));
+        chore.setSpaceChore(spaceChore);
 
         return ChoreDto.Response.fromEntity(chore);
     }

--- a/src/main/java/com/zerobase/homemate/entity/Chore.java
+++ b/src/main/java/com/zerobase/homemate/entity/Chore.java
@@ -1,7 +1,6 @@
 package com.zerobase.homemate.entity;
 
 import com.zerobase.homemate.entity.enums.RepeatType;
-import com.zerobase.homemate.entity.enums.Space;
 import jakarta.persistence.*;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
@@ -77,9 +76,10 @@ public class Chore {
     private User user;
 
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Space space;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "space_chore_id")
+    @Setter
+    private SpaceChore spaceChore;
 
 
     @OneToMany(mappedBy = "chore", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/zerobase/homemate/recommend/dto/ChoreResponse.java
+++ b/src/main/java/com/zerobase/homemate/recommend/dto/ChoreResponse.java
@@ -6,13 +6,17 @@ import com.zerobase.homemate.entity.enums.RepeatType;
 
 public record ChoreResponse(Long choreId,
                             String title,
-                            String frequency) {
+                             String frequency,
+                            Long spaceChoreId,
+                            String spaceChoreName) {
 
     public static ChoreResponse fromEntity(Chore chore) {
         return new ChoreResponse(
                 chore.getId(),
                 chore.getTitle(),
-                formatFrequency(chore.getRepeatType(), chore.getRepeatInterval())
+                formatFrequency(chore.getRepeatType(), chore.getRepeatInterval()),
+                chore.getSpaceChore().getId(),
+                chore.getSpaceChore().getTitleKo()
         );
     }
 

--- a/src/main/java/com/zerobase/homemate/recommend/service/SpaceService.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/SpaceService.java
@@ -1,9 +1,13 @@
 package com.zerobase.homemate.recommend.service;
 
 import com.zerobase.homemate.entity.Chore;
+import com.zerobase.homemate.entity.SpaceChore;
 import com.zerobase.homemate.entity.enums.Space;
+import com.zerobase.homemate.exception.CustomException;
+import com.zerobase.homemate.exception.ErrorCode;
 import com.zerobase.homemate.recommend.dto.ChoreResponse;
 import com.zerobase.homemate.repository.ChoreRepository;
+import com.zerobase.homemate.repository.SpaceChoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,10 +20,19 @@ import java.util.Map;
 public class SpaceService {
 
     private final ChoreRepository choreRepository;
+    private final SpaceChoreRepository spaceChoreRepository;
 
     public List<ChoreResponse> getChoresBySpace(Space space){
-        List<Chore> chores = choreRepository.findBySpaceAndIsDeletedFalse(space);
 
+        // Enum으로부터 SpaceChore Entity를 조회한다.
+        SpaceChore spaceChore = spaceChoreRepository.findBySpace(space).orElseThrow(
+                () -> new CustomException(ErrorCode.SPACE_NOT_FOUND)
+        );
+
+        // SpaceChore 기준으로 Chore를 조회한다.
+        List<Chore> chores = choreRepository.findBySpaceChoreAndIsDeletedFalse(spaceChore);
+
+        // 응답을 최대 4개까지 반환한다.
         return chores.stream()
                 .map(ChoreResponse::fromEntity)
                 .limit(4)

--- a/src/main/java/com/zerobase/homemate/repository/ChoreRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoreRepository.java
@@ -1,7 +1,7 @@
 package com.zerobase.homemate.repository;
 
 import com.zerobase.homemate.entity.Chore;
-import com.zerobase.homemate.entity.enums.Space;
+import com.zerobase.homemate.entity.SpaceChore;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.stereotype.Repository;
@@ -13,5 +13,5 @@ import java.util.List;
 public interface ChoreRepository extends JpaRepository<Chore, Long> {
 
     // Space 기준으로 사용자 chore 조회
-    List<Chore> findBySpaceAndIsDeletedFalse(Space space);
+    List<Chore> findBySpaceChoreAndIsDeletedFalse(SpaceChore spaceChore);
 }

--- a/src/main/java/com/zerobase/homemate/repository/SpaceChoreRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/SpaceChoreRepository.java
@@ -2,9 +2,14 @@ package com.zerobase.homemate.repository;
 
 
 import com.zerobase.homemate.entity.SpaceChore;
+import com.zerobase.homemate.entity.enums.Space;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 
 public interface SpaceChoreRepository extends JpaRepository<SpaceChore, Long> {
+
+    Optional<SpaceChore> findBySpace(Space space);
 
 }

--- a/src/test/java/com/zerobase/homemate/space/SpaceControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/space/SpaceControllerTest.java
@@ -45,8 +45,8 @@ class SpaceControllerTest {
     @Test
     void testGetChoresBySpace() throws Exception {
         // given
-        ChoreResponse chore1 = new ChoreResponse(1L, "청소", "매주");
-        ChoreResponse chore2 = new ChoreResponse(2L, "설거지", "매일");
+        ChoreResponse chore1 = new ChoreResponse(1L, "청소", "매주", 101L, "주방 청소");
+        ChoreResponse chore2 = new ChoreResponse(2L, "설거지", "매일", 102L, "주방 설거지");
 
         when(spaceService.getChoresBySpace(Space.KITCHEN))
                 .thenReturn(List.of(chore1, chore2));
@@ -59,9 +59,13 @@ class SpaceControllerTest {
                 .andExpect(jsonPath("$[0].choreId").value(1))
                 .andExpect(jsonPath("$[0].title").value("청소"))
                 .andExpect(jsonPath("$[0].frequency").value("매주"))
+                .andExpect(jsonPath("$[0].spaceChoreId").value(101L))
+                .andExpect(jsonPath("$[0].spaceChoreName").value("주방 청소"))
                 .andExpect(jsonPath("$[1].choreId").value(2))
                 .andExpect(jsonPath("$[1].title").value("설거지"))
-                .andExpect(jsonPath("$[1].frequency").value("매일"));
+                .andExpect(jsonPath("$[1].frequency").value("매일"))
+                .andExpect(jsonPath("$[1].spaceChoreId").value(102L))
+                .andExpect(jsonPath("$[1].spaceChoreName").value("주방 설거지"));
 
         verify(spaceService, times(1)).getChoresBySpace(Space.KITCHEN);
     }

--- a/src/test/java/com/zerobase/homemate/space/SpaceServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/space/SpaceServiceTest.java
@@ -2,11 +2,13 @@ package com.zerobase.homemate.space;
 
 
 import com.zerobase.homemate.entity.Chore;
+import com.zerobase.homemate.entity.SpaceChore;
 import com.zerobase.homemate.entity.enums.RepeatType;
 import com.zerobase.homemate.entity.enums.Space;
 import com.zerobase.homemate.recommend.dto.ChoreResponse;
 import com.zerobase.homemate.recommend.service.SpaceService;
 import com.zerobase.homemate.repository.ChoreRepository;
+import com.zerobase.homemate.repository.SpaceChoreRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -14,30 +16,49 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class SpaceServiceTest {
+
     @Mock
     private ChoreRepository choreRepository;
+
+    @Mock
+    private SpaceChoreRepository spaceChoreRepository;
 
     @InjectMocks
     private SpaceService spaceService;
 
+    private SpaceChore kitchenSpaceChore;
+
     @BeforeEach
     void setUp() {
+
         MockitoAnnotations.openMocks(this);
+
+        // given : SpaceChore(주방)
+
+        kitchenSpaceChore = SpaceChore.builder()
+                .id(1L)
+                .code("KITCHEN_DEFAULT")
+                .titleKo("주방")
+                .isActive(true)
+                .defaultFreq(RepeatType.DAILY)
+                .space(Space.KITCHEN)
+                .build();
     }
 
     @Test
     void testGetChoresBySpace() {
-        // given
+        // given: Chore 두 개 생성
         Chore chore1 = Chore.builder()
                 .id(1L)
                 .title("청소")
                 .repeatType(RepeatType.WEEKLY)
-                .space(Space.KITCHEN)
+                .spaceChore(kitchenSpaceChore)
                 .isDeleted(false)
                 .build();
 
@@ -45,11 +66,14 @@ public class SpaceServiceTest {
                 .id(2L)
                 .title("설거지")
                 .repeatType(RepeatType.DAILY)
-                .space(Space.KITCHEN)
+                .spaceChore(kitchenSpaceChore)
                 .isDeleted(false)
                 .build();
 
-        when(choreRepository.findBySpaceAndIsDeletedFalse(Space.KITCHEN))
+        when(spaceChoreRepository.findBySpace(Space.KITCHEN))
+                .thenReturn(Optional.of(kitchenSpaceChore));
+
+        when(choreRepository.findBySpaceChoreAndIsDeletedFalse(kitchenSpaceChore))
                 .thenReturn(List.of(chore1, chore2));
 
         // when
@@ -60,12 +84,14 @@ public class SpaceServiceTest {
         assertEquals("청소", result.get(0).title());
         assertEquals("설거지", result.get(1).title());
 
-        verify(choreRepository, times(1)).findBySpaceAndIsDeletedFalse(Space.KITCHEN);
+        verify(spaceChoreRepository, times(1)).findBySpace(Space.KITCHEN);
+        verify(choreRepository, times(1)).findBySpaceChoreAndIsDeletedFalse(kitchenSpaceChore);
     }
 
     @Test
     void testGetAllSpaces() {
         var result = spaceService.getAllSpaces();
+
         assertEquals(Space.values().length, result.size());
         assertEquals("KITCHEN", result.get(0).get("name"));
         assertEquals("주방", result.get(0).get("description"));


### PR DESCRIPTION
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 10월 12일부 origin/develop branch의 상태에서 진행하였습니다.
- ChoreService의 createChores에서 setSpace가 원활하게 작동하지 않는다는 점을 발견하였습니다.
-
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- Chore Entity에서 SpaceChore Entity를 조회하게끔 내부적으로 설정하였으며,
- ChoreDto에서는 SpaceChore의 Id와 Name을 가져오게끔 설정하였습니다.
- Space Parameter를 참조하던 ChoreRepository에서 SpaceChore Parameter를 참조하도록 설정하였습니다.
- ChoreResponse에서 spaceChoreId, spaceChoreName을 같이 반환하도록 변경하였습니다.
- SpaceChoreRepository에서 Space을 참조하도록 하여 유저는 Space만 신경쓰는 구조를 유지하도록 변경하였습니다.


## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- Chore <-> SpaceChore <-> Space의 관계로 조회가 진행이 됩니다.
- Chore Entity에 있는 SpaceChore Parameter에 대하여 @Setter를 추가하였습니다.

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 
- [x] API 테스트 
<img width="346" height="471" alt="image" src="https://github.com/user-attachments/assets/ad7d4b27-7b03-4425-9704-34d684d862aa" />
공간 리스트 조회 - 이상 없습니다.

<img width="405" height="371" alt="image" src="https://github.com/user-attachments/assets/f021b874-e93b-4192-9068-2d329284b11c" />
공간에 속해 있는 집안일 조회 - spaceChoreId, spaceChoreName이 추가되어서 나타납니다. 조회 동작 이상 없습니다.