### PR TITLE
[fix] 맞춤 알림 시간이 없을 때의 알림 생성 오류 수정

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -6,6 +6,7 @@ import com.zerobase.homemate.chore.dto.ChoreInstanceDto;
 import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
 import com.zerobase.homemate.entity.User;
+import com.zerobase.homemate.entity.UserNotificationSetting;
 import com.zerobase.homemate.entity.enums.ChoreStatus;
 import com.zerobase.homemate.entity.enums.RepeatType;
 import com.zerobase.homemate.entity.enums.UserActionType;
@@ -21,6 +22,7 @@ import com.zerobase.homemate.repository.UserRepository;
 import com.zerobase.homemate.util.ChoreInstanceGenerator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.EnumSet;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -93,9 +95,21 @@ public class ChoreService {
         missionService.increaseMissionCountForAction(
             userId, UserActionType.CREATE_CHORE_MANUAL);
 
+        // 맞춤 알림 시간이 null일 경우 마이페이지 시간 -> 없으면 기본값(19:00) 사용
+        LocalTime notificationTime = request.getNotificationTime();
+        if (notificationTime == null) {
+            notificationTime = userNotificationSettingRepository.findByUser(userReference)
+                    .map(UserNotificationSetting::getNotificationTime)
+                    .orElseGet(() -> LocalTime.of(19, 0)); // default time
+        }
+
         // TODO: for-loop 대신 배치 처리 구현
         for (ChoreInstance instance : instances) {
-            eventPublisher.publishEvent(ChoreInstanceCreatedEvent.create(userId, instance, savedChore.getRepeatType()));
+            eventPublisher.publishEvent(ChoreInstanceCreatedEvent.create(userId,
+                    instance,
+                    notificationTime,
+                    savedChore.getRepeatType()
+            ));
         }
 
         redisChoreStatsService.increment(null, request.getSpace());

--- a/src/main/java/com/zerobase/homemate/notification/component/ChoreInstanceCreatedEvent.java
+++ b/src/main/java/com/zerobase/homemate/notification/component/ChoreInstanceCreatedEvent.java
@@ -18,10 +18,8 @@ public class ChoreInstanceCreatedEvent {
     private RepeatType repeatType;
     private LocalDateTime scheduledAt;
 
-    public static ChoreInstanceCreatedEvent create(Long userId, ChoreInstance choreInstance, RepeatType repeatType) {
-        LocalDate dueDate = choreInstance.getDueDate();
-        LocalTime notificationTime = choreInstance.getNotificationTime();
-        LocalDateTime scheduledAt = LocalDateTime.of(dueDate, notificationTime);
+    public static ChoreInstanceCreatedEvent create(Long userId, ChoreInstance choreInstance, LocalTime notificationTime, RepeatType repeatType) {
+        LocalDateTime scheduledAt = LocalDateTime.of(choreInstance.getDueDate(), notificationTime);
 
         return ChoreInstanceCreatedEvent.builder()
                 .userId(userId)


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

- 
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- 

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

- 맞춤 알림 시간이 없으면 마이페이지 설정 시간을 사용
- 마이페이지 시간 설정이 되어있지 않으면 기본값(19:00) 사용

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 