### PR TITLE
[fix] random-chores-repository 수정 내용

### DIFF
--- a/src/main/java/com/zerobase/homemate/repository/SpaceChoreRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/SpaceChoreRepository.java
@@ -22,7 +22,7 @@ public interface SpaceChoreRepository extends JpaRepository<SpaceChore, Long> {
 """)
     List<SpaceChore> findBySpace(Space space, Pageable pageable);
 
-    @Query(value = "SELECT id, title_ko FROM space_chores ORDER BY RAND() LIMIT 3", nativeQuery = true)
+    @Query(value = "SELECT id, title_ko, space FROM space_chores ORDER BY RAND() LIMIT 3", nativeQuery = true)
     List<SpaceChoreResponse> findRandomChores();
            
     Optional<SpaceChore> findByTitleKo(String title);


### PR DESCRIPTION
- API 호출 시 getSpace() 부분이 무조건적으로 null로 찍히는 현상을 확인했습니다.
- Repository 단계에서 변경에 누락된 부분이 확인되어 추가로 commit드립니다.

<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 랜덤 집안일 추천 기능 시 SpaceChore에 저장된 집안일 3개 구현
- id, 집안일 이름만을 출력하던 부분에서 -> space Parameter 추가된 상황
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- null이 나오는 부분에 대하여 Repository 레벨에서 space Parameter를 가지고 오질 않고 있는 문제점이 발견되었습니다.
-

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- null이 나오는 부분에 대하여 Repository 레벨에서 space Parameter를 가지고 오질 않고 있는 문제점이 발견되었습니다.

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 
<img width="404" height="392" alt="image" src="https://github.com/user-attachments/assets/a90df441-7cdf-44c3-835b-b8fc439e31d3" />
이전에는, 여기서 space Parameter가 모두 null로 나타났는데, Repository에서 space Parameter를 조회하고 SpaceChoreResponse에 올바르게 전달되는 양상입니다.