### PR TITLE
[feat] 이 달의 미션 추천 카테고리 YN 값 추가 & 미션 달성 로직 개선 #147

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -356,7 +356,8 @@ public class ChoreService {
 
         if (choreInstance.getChoreStatus() == ChoreStatus.PENDING ||
             choreInstance.getChoreStatus() == ChoreStatus.COMPLETED) {
-            if (chore.getRepeatType() == RepeatType.NONE) {
+            if (chore.getRepeatType() == RepeatType.NONE ||
+                chore.getStartDate().equals(chore.getEndDate())) {
                 choreInstance.softDelete();
                 chore.softDelete();
             } else {

--- a/src/main/java/com/zerobase/homemate/entity/UserMission.java
+++ b/src/main/java/com/zerobase/homemate/entity/UserMission.java
@@ -68,11 +68,13 @@ public class UserMission {
     }
 
     public boolean incrementCount() {
-        int next = this.currentCount + 1;
-        this.currentCount = next;
-
         Integer target = this.mission.getTargetCount();
-        if (target != null && next >= target) {
+
+        if (target == null || this.currentCount < target) {
+            this.currentCount += 1;
+        }
+
+        if (target != null && this.currentCount >= target) {
             this.isCompleted = true;
             this.completedAt = LocalDateTime.now();
             return true;

--- a/src/main/java/com/zerobase/homemate/mission/dto/MissionDto.java
+++ b/src/main/java/com/zerobase/homemate/mission/dto/MissionDto.java
@@ -23,9 +23,10 @@ public class MissionDto {
         private Integer targetCount;
         private Integer currentCount;
         private boolean isCompleted;
+        private boolean existsInRecommend;
 
         public static Response of(Mission mission,
-            @Nullable UserMission userMission) {
+            @Nullable UserMission userMission, boolean existsInRecommend) {
             int currentCount =
                 (userMission != null) ? userMission.getCurrentCount() : 0;
             boolean isCompleted =
@@ -37,6 +38,7 @@ public class MissionDto {
                 .targetCount(mission.getTargetCount())
                 .currentCount(currentCount)
                 .isCompleted(isCompleted)
+                .existsInRecommend(existsInRecommend)
                 .build();
         }
     }

--- a/src/main/java/com/zerobase/homemate/mission/service/MissionService.java
+++ b/src/main/java/com/zerobase/homemate/mission/service/MissionService.java
@@ -12,12 +12,14 @@ import com.zerobase.homemate.entity.enums.UserActionType;
 import com.zerobase.homemate.mission.dto.MissionDto;
 import com.zerobase.homemate.repository.MissionProgressRepository;
 import com.zerobase.homemate.repository.MissionRepository;
+import com.zerobase.homemate.repository.SpaceChoreRepository;
 import com.zerobase.homemate.repository.UserMissionRepository;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class MissionService {
     private final MissionProgressRepository missionProgressRepository;
     private final UserBadgeStatsService userBadgeStatsService;
     private final BadgeService badgeService;
+    private final SpaceChoreRepository spaceChoreRepository;
 
     public List<MissionDto.Response> getMonthlyMissions(long userId) {
 
@@ -57,14 +60,17 @@ public class MissionService {
         return monthlyMissions.stream()
             .map(mission -> {
                 UserMission userMission = userMissionMap.get(mission.getId());
+                boolean existsInRecommend = existsInSpaceChores(mission.getTitle());
                 return (userMission != null)
-                    ? MissionDto.Response.of(mission, userMission)
+                    ? MissionDto.Response.of(mission, userMission,
+                    existsInRecommend)
                     : MissionDto.Response.builder()
                         .id(mission.getId())
                         .title(mission.getTitle())
                         .targetCount(mission.getTargetCount())
                         .currentCount(0)
                         .isCompleted(false)
+                        .existsInRecommend(existsInRecommend)
                         .build();
             })
             .toList();
@@ -129,11 +135,15 @@ public class MissionService {
             MissionProgress missionProgress =
                 progressByUserMissionId.get(userMission.getId());
 
+            boolean existsInRecommend = existsInSpaceChores(mission.getTitle());
+
             if (isPending) {
                 applyCompletion(userMission, missionProgress, choreInstance,
                     toSave, counterUserMission);
+                if (userMission.isAlreadyCompleted()) continue;
                 if (userMission.getIsCompleted()) {
-                    response.add(MissionDto.Response.of(mission, userMission));
+                    response.add(MissionDto.Response.of(mission, userMission,
+                     existsInRecommend));
                 }
             } else {
                 revertCompletion(userMission, missionProgress, choreInstance,
@@ -154,6 +164,12 @@ public class MissionService {
             .toList();
     }
 
+    private boolean existsInSpaceChores(String missionTitle) {
+        // TODO : 추천 카테고리 미션 집안일 추가되면 카테고리로 수정
+        List<String> spaceChoreTitles = spaceChoreRepository.findAllTitles();
+        return spaceChoreTitles.stream().anyMatch(t -> qualifiesChoreTitle(missionTitle, t));
+    }
+
     private boolean qualifies(Mission mission, ChoreInstance choreInstance) {
         UserActionType type = mission.getUserActionType();
         String missionTitle = mission.getTitle();
@@ -163,10 +179,28 @@ public class MissionService {
 
         return switch (type) {
             case COMPLETE_ANY_CHORE -> true;
-            case COMPLETE_CHORE -> missionTitle.equals(choreTitle);
+            case COMPLETE_CHORE -> qualifiesChoreTitle(missionTitle, choreTitle);
             case COMPLETE_CHORE_WITH_SPACE -> missionSpace.equals(choreSpace);
             default -> false;
         };
+    }
+
+    private boolean qualifiesChoreTitle(String missionTitle, String choreTitle) {
+        if (missionTitle == null || choreTitle == null) return false;
+
+        missionTitle = missionTitle.replaceAll("\\s+", "");
+        choreTitle = choreTitle.replaceAll("\\s+", "");
+
+        Set<Character> missionChars = missionTitle.chars()
+            .mapToObj(c -> (char) c)
+            .collect(Collectors.toSet());
+
+        for (char c : choreTitle.toCharArray()) {
+            if (!missionChars.contains(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void applyCompletion(UserMission userMission,
@@ -237,6 +271,10 @@ public class MissionService {
             return List.of();
         }
 
+        if (userMission.isAlreadyCompleted()) {
+            return List.of();
+        }
+
         userMission.incrementCount();
 
         missionProgressRepository.save(
@@ -245,6 +283,8 @@ public class MissionService {
                 .build()
         );
 
-        return List.of(MissionDto.Response.of(mission, userMission));
+        boolean existsInRecommend = existsInSpaceChores(mission.getTitle());
+
+        return List.of(MissionDto.Response.of(mission, userMission, existsInRecommend));
     }
 }

--- a/src/main/java/com/zerobase/homemate/repository/SpaceChoreRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/SpaceChoreRepository.java
@@ -28,4 +28,7 @@ public interface SpaceChoreRepository extends JpaRepository<SpaceChore, Long> {
     Optional<SpaceChore> findByTitleKo(String title);
 
     Long countBySpace(Space space);
+
+    @Query("SELECT sc.titleKo FROM SpaceChore sc")
+    List<String> findAllTitles();
 }

--- a/src/test/java/com/zerobase/homemate/badge/BadgeServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/badge/BadgeServiceTest.java
@@ -32,6 +32,7 @@ class BadgeService30CompletionTest {
     private UserMissionRepository userMissionRepository;
     private MissionAssignmentService missionAssignmentService;
     private MissionProgressRepository missionProgressRepository;
+    private SpaceChoreRepository spaceChoreRepository;
 
     private User user;
     private UserMission userMission;
@@ -49,6 +50,7 @@ class BadgeService30CompletionTest {
         userMissionRepository = mock(UserMissionRepository.class);
         missionAssignmentService = mock(MissionAssignmentService.class);
         missionProgressRepository = mock(MissionProgressRepository.class);
+        spaceChoreRepository = mock(SpaceChoreRepository.class);
 
 
         missionService = new MissionService(
@@ -57,7 +59,8 @@ class BadgeService30CompletionTest {
                 missionAssignmentService,
                 missionProgressRepository,
                 userBadgeStatsService,
-                badgeService
+                badgeService,
+                spaceChoreRepository
         );
 
         user = User.builder()


### PR DESCRIPTION
 ## 📝 계획
### 기존 상태
- 집안일 삭제 시 시작일, 종료일 같은 경우 전/후 날짜를 찾다가 에러 발생
- 달성된 미션 관련된 행동 시 미션 결과 계속 클라이언트로 전달
- 집안일 완료 미션 달성 조건 : 완료된 집안일 이름 = 미션 이름

### 변경 후 상태
- 이달의 미션 조회 시 추천 집안일 관련된 미션 여부 추가
- 집안일 삭제 시 시작일, 종료일 같은 경우 단건 삭제 진행
- 달성된 미션 관련된 행동 시 기존 달성 미션이라면 전달 X
- 집안일 완료 미션 달성 조건 : 완료된 집안일 이름 전체가 미션 이름에 포함된 글자면 카운트 증가

## 💡PR에서 핵심적으로 변경된 사항
- ```MissionService```
  - ```existsInSpaceChores()``` : 추천 탭에 존재하는 집안일과 관련된 미션 YN 값
  - ```qualifiesChoreTitle()``` : 집안일 이름 전체가 미션 이름에 포함된 글자인지 확인

## 📢이외 추가 변경 부분 및 기타화
## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 

# 포스트맨 테스트
- 미션 조회 시 추천 카테고리 YN 값 반환
<img width="722" height="675" alt="image" src="https://github.com/user-attachments/assets/b4c59812-3ca4-425b-a891-8ebae8debc34" />

- '설거지 하기' 완료
<img width="720" height="759" alt="image" src="https://github.com/user-attachments/assets/acf23859-0bfc-4f71-a613-c4431cae71a5" />
<img width="828" height="106" alt="image" src="https://github.com/user-attachments/assets/2d926ab6-5373-4603-b9bf-1040fc6eae8d" />
<img width="1013" height="40" alt="image" src="https://github.com/user-attachments/assets/6d423b18-0265-49a8-8563-8ce729a38f82" />
