### PR TITLE
[fix] 향후 반복일정 집안일 삭제하기 종료일 미반영 오류 #157

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -363,43 +363,15 @@ public class ChoreService {
                 choreInstance.softDelete();
                 chore.softDelete();
             } else {
-                EnumSet<ChoreStatus> includedStatuses =
-                    EnumSet.of(ChoreStatus.PENDING, ChoreStatus.COMPLETED);
-                if (choreInstance.getDueDate().equals(chore.getStartDate())) {
-                    LocalDate nextDate = choreInstanceGenerator.getNextDate(
-                        choreInstance.getDueDate(),
-                        chore.getRepeatType(),
-                        chore.getRepeatInterval());
-
-                    while(!choreInstanceRepository.existsByChoreAndDueDateAndChoreStatusIn(chore, nextDate, includedStatuses)) {
-                        nextDate = choreInstanceGenerator.getNextDate(
-                            nextDate,
-                            chore.getRepeatType(),
-                            chore.getRepeatInterval());
-                    }
-
-                    chore.setStartDate(nextDate);
-                } else if (choreInstance.getDueDate().equals(chore.getEndDate())) {
-                    LocalDate beforeDate = choreInstanceGenerator.getBeforeDate(
-                        choreInstance.getDueDate(),
-                        chore.getRepeatType(),
-                        chore.getRepeatInterval());
-
-                    while(!choreInstanceRepository.existsByChoreAndDueDateAndChoreStatusIn(chore, beforeDate, includedStatuses)) {
-                        beforeDate = choreInstanceGenerator.getBeforeDate(
-                            beforeDate,
-                            chore.getRepeatType(),
-                            chore.getRepeatInterval());
-                    }
-
-                    chore.setEndDate(beforeDate);
-                }
-
                 if (applyToAfter) {
+                    if (!choreInstance.getDueDate().equals(chore.getStartDate())) {
+                        setStartDateEndDateForCase(chore, choreInstance, applyToAfter);
+                    }
                     choreInstanceRepository.bulkSoftDeleteAfterByChoreAndStatuses(
                         chore, choreInstance.getDueDate(),
                         ChoreStatus.DELETED, LocalDateTime.now());
                 } else {
+                    setStartDateEndDateForCase(chore, choreInstance, applyToAfter);
                     choreInstance.softDelete();
                 }
             }
@@ -407,6 +379,41 @@ public class ChoreService {
             softDeleteChoreIfAllInstancesDeleted(chore);
         } else {
             throw new CustomException(ErrorCode.CHORE_ALREADY_DELETED);
+        }
+    }
+
+    private void setStartDateEndDateForCase(
+        Chore chore, ChoreInstance choreInstance, boolean applyToAfter) {
+        EnumSet<ChoreStatus> includedStatuses =
+            EnumSet.of(ChoreStatus.PENDING, ChoreStatus.COMPLETED);
+        if (choreInstance.getDueDate().equals(chore.getStartDate())) {
+            LocalDate nextDate = choreInstanceGenerator.getNextDate(
+                choreInstance.getDueDate(),
+                chore.getRepeatType(),
+                chore.getRepeatInterval());
+
+            while(!choreInstanceRepository.existsByChoreAndDueDateAndChoreStatusIn(chore, nextDate, includedStatuses)) {
+                nextDate = choreInstanceGenerator.getNextDate(
+                    nextDate,
+                    chore.getRepeatType(),
+                    chore.getRepeatInterval());
+            }
+
+            chore.setStartDate(nextDate);
+        } else if (choreInstance.getDueDate().equals(chore.getEndDate()) || applyToAfter) {
+            LocalDate beforeDate = choreInstanceGenerator.getBeforeDate(
+                choreInstance.getDueDate(),
+                chore.getRepeatType(),
+                chore.getRepeatInterval());
+
+            while(!choreInstanceRepository.existsByChoreAndDueDateAndChoreStatusIn(chore, beforeDate, includedStatuses)) {
+                beforeDate = choreInstanceGenerator.getBeforeDate(
+                    beforeDate,
+                    chore.getRepeatType(),
+                    chore.getRepeatInterval());
+            }
+
+            chore.setEndDate(beforeDate);
         }
     }
 


### PR DESCRIPTION
## 📝 계획
### 기존 상태
- 반복 집안일 중간 날짜 기준 향후 일정 삭제 시 집안일 종료일 설정 미반영
- 반복 집안일 시작일 다음 인스턴스 향후 일정 삭제 후 남은 집안일 삭제 시 UNKNOWN 에러 발생

### 변경 후 상태
- 반복 집안일 중간 날짜 기준 향후 일정 삭제 시 집안일 종료일 마지막 인스턴스 날짜로 설정
- 반복 집안일 시작일 다음 인스턴스 향후 일정 삭제 후 남은 집안일 삭제 시 정상 기능 동작

## 💡PR에서 핵심적으로 변경된 사항
- ```ChoreService```
  - ```setStartDateEndDateForCase()``` 메서드 추가

## 📢이외 추가 변경 부분 및 기축
- 기존 코드에서는 시작일/종료일 설정 후 단일 인스턴스 삭제/향후 인스턴스 삭제를 나눠서 while 문이 종료되지 않았습니다.
- 시작일, 종료일, 향후일정여부 값을 사용한 날짜 세팅 메서드를 따로 빼고, 향후 일정 여부를 판단할때 1회만 while 문 호출하도록 수정했습니다.

## ✅ 테스트 
- [ ] 테스트 코드
- [X] API 테스트 