### PR TITLE
[fix] 집안일 직접 추가하기 추천 집안일 클릭시 전달 팩터 추가 #159

### DIFF
--- a/src/main/java/com/zerobase/homemate/recommend/controller/SpaceController.java
+++ b/src/main/java/com/zerobase/homemate/recommend/controller/SpaceController.java
@@ -57,6 +57,7 @@ public class SpaceController {
     public ResponseEntity<SpaceChoreDto.Response> getSpaceChore(
         @AuthenticationPrincipal UserPrincipal user,
         @PathVariable Long spaceChoreId) {
-        return ResponseEntity.ok(spaceService.getSpaceChore(spaceChoreId));
+        return ResponseEntity.ok(
+            spaceService.getSpaceChore(user.id(), spaceChoreId));
     }
 }

--- a/src/main/java/com/zerobase/homemate/recommend/dto/SpaceChoreDto.java
+++ b/src/main/java/com/zerobase/homemate/recommend/dto/SpaceChoreDto.java
@@ -3,8 +3,10 @@ package com.zerobase.homemate.recommend.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zerobase.homemate.entity.SpaceChore;
+import com.zerobase.homemate.entity.UserNotificationSetting;
 import com.zerobase.homemate.entity.enums.RepeatType;
 import com.zerobase.homemate.entity.enums.Space;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,15 +38,23 @@ public class SpaceChoreDto {
         private RepeatType repeatType;
         private Integer repeatInterval;
         private Space space;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private boolean choreEnabled;
 
-        public static SpaceChoreDto.Response fromEntity(SpaceChore spaceChore) {
-            return SpaceChoreDto.Response.builder()
+        public static SpaceChoreDto.Response of(SpaceChore spaceChore,
+            UserNotificationSetting userNotificationSetting,
+            LocalDate endDate) {
+            return Response.builder()
                 .id(spaceChore.getId())
                 .code(spaceChore.getCode())
                 .titleKo(spaceChore.getTitleKo())
                 .repeatType(spaceChore.getRepeatType())
                 .repeatInterval(spaceChore.getRepeatInterval())
                 .space(spaceChore.getSpace())
+                .startDate(LocalDate.now())
+                .endDate(endDate)
+                .choreEnabled(userNotificationSetting.isChoreEnabled())
                 .build();
         }
     }

--- a/src/main/java/com/zerobase/homemate/recommend/service/SpaceService.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/SpaceService.java
@@ -1,6 +1,7 @@
 package com.zerobase.homemate.recommend.service;
 
 import com.zerobase.homemate.entity.SpaceChore;
+import com.zerobase.homemate.entity.UserNotificationSetting;
 import com.zerobase.homemate.entity.enums.RepeatType;
 import com.zerobase.homemate.entity.enums.Space;
 import com.zerobase.homemate.exception.CustomException;
@@ -9,6 +10,9 @@ import com.zerobase.homemate.recommend.dto.ClassifyChoreResponse;
 import com.zerobase.homemate.recommend.dto.SpaceChoreDto;
 import com.zerobase.homemate.recommend.dto.SpaceResponse;
 import com.zerobase.homemate.repository.SpaceChoreRepository;
+import com.zerobase.homemate.repository.UserNotificationSettingRepository;
+import com.zerobase.homemate.util.ChoreDateUtils;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +25,7 @@ import java.util.*;
 public class SpaceService {
 
     private final SpaceChoreRepository spaceChoreRepository;
+    private final UserNotificationSettingRepository userNotificationSettingRepository;
     private final int DEFAULT_LIMIT = 5;
 
     private static final Map<RepeatType, Integer> REPEAT_PRIORITY = Map.of(
@@ -66,9 +71,15 @@ public class SpaceService {
                 .toList();
     }
 
-    public SpaceChoreDto.Response getSpaceChore(Long spaceChoreId) {
+    public SpaceChoreDto.Response getSpaceChore(
+        Long userId, Long spaceChoreId) {
         SpaceChore spaceChore = spaceChoreRepository.findById(spaceChoreId)
             .orElseThrow(() -> new CustomException(ErrorCode.CHORE_NOT_FOUND));
-        return SpaceChoreDto.Response.fromEntity(spaceChore);
+        UserNotificationSetting userNotificationSetting =
+            userNotificationSettingRepository.findByUserId(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        LocalDate endDate = ChoreDateUtils.calculateEndDate(LocalDate.now(),
+            spaceChore.getRepeatType(),
+            spaceChore.getRepeatInterval());
+        return SpaceChoreDto.Response.of(spaceChore, userNotificationSetting, endDate);
     }
 }


### PR DESCRIPTION
## 📝 계획
### 기존 상태
- 공간 집안일 가져오는 API 반환 값 : ```Space``` Entity 에서만 가져옴

### 변경 후 상태
- 공간 집안일 가져오는 API 기존 반환 값에 ```UserNotificationSetting``` 의 집안일 알림 여부 값, 시작일, 종료일 추가

## 💡PR에서 핵심적으로 변경된 사항
- ```SpaceService``` : ```UserNotificationSetting```, ```ChoreDateUtil``` 사용하여 알림 여부, 시작일, 종료일 값 도출

## 📢이외 추가 변경 부분 및 기타
## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 