### PR TITLE
[fix] 추천 집안일 정보 가져오기 팩터 추가 및 집안일 달성률 파라미터 추가 #161

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -101,12 +101,13 @@ public class ChoreController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/today-rate")
+    @GetMapping("/today-rate/{today}")
     public ResponseEntity<Map<String, Double>> getTodayCompleteRate(
-        @AuthenticationPrincipal UserPrincipal user
+        @AuthenticationPrincipal UserPrincipal user,
+        @PathVariable LocalDate today
     ) {
 
-        double rate = choreService.getTodayCompleteRate(user.id());
+        double rate = choreService.getTodayCompleteRate(user.id(), today);
 
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("rate", rate));
     }

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -428,13 +428,13 @@ public class ChoreService {
         }
     }
 
-    public double getTodayCompleteRate(Long userId) {
+    public double getTodayCompleteRate(Long userId, LocalDate today) {
         EnumSet<ChoreStatus> includedStatuses =
             EnumSet.of(ChoreStatus.PENDING, ChoreStatus.COMPLETED);
 
         ChoreCounts counts =
             choreInstanceRepository.countTodayTotalsAndCompleted(
-                userId, LocalDate.now(), includedStatuses);
+                userId, today, includedStatuses);
 
         long total = counts.total();
         if (total == 0) {

--- a/src/main/java/com/zerobase/homemate/recommend/dto/SpaceChoreDto.java
+++ b/src/main/java/com/zerobase/homemate/recommend/dto/SpaceChoreDto.java
@@ -7,6 +7,7 @@ import com.zerobase.homemate.entity.UserNotificationSetting;
 import com.zerobase.homemate.entity.enums.RepeatType;
 import com.zerobase.homemate.entity.enums.Space;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +42,7 @@ public class SpaceChoreDto {
         private LocalDate startDate;
         private LocalDate endDate;
         private boolean choreEnabled;
+        private LocalTime notificationTime;
 
         public static SpaceChoreDto.Response of(SpaceChore spaceChore,
             UserNotificationSetting userNotificationSetting,
@@ -55,6 +57,7 @@ public class SpaceChoreDto {
                 .startDate(LocalDate.now())
                 .endDate(endDate)
                 .choreEnabled(userNotificationSetting.isChoreEnabled())
+                .notificationTime(userNotificationSetting.getNotificationTime())
                 .build();
         }
     }

--- a/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
@@ -78,7 +78,7 @@ public interface ChoreInstanceRepository extends JpaRepository<ChoreInstance, Lo
     """)
     ChoreCounts countTodayTotalsAndCompleted(
         @Param("userId") Long userId,
-        @Param("today") LocalDate date,
+        @Param("today") LocalDate today,
         @Param("included") Set<ChoreStatus> included
     );
 


### PR DESCRIPTION
## 📝 계획
### 기존 상태
- 홈 화면에서 달력의 날짜별로 클릭 시 해당 일자의 달성률 조회
- 집안일 직접 추가하기의 추천 집안일 정보에 알림 시간 누락

### 변경 후 상태
- 클라이언트 단에서 날짜를 받아 해당 날짜만 조회하도록 변경
- 추천 집안일 정보 가져오기 API 에 알림 시간 추가

## 💡PR에서 핵심적으로 변경된 사항
- ```ChoreController``` : 클라이언트로부터 ```{today}``` 파라미터 수신
- ```SpaceChoreDto``` : ```notificationTime``` 팩터 추가 반환

## 📢이외 추가 변경 부분 및 기타
## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 