### PR TITLE
[fix] 월간 카테고리 조회 기능 -> code 에서 category 변경 건

### DIFF
--- a/src/main/java/com/zerobase/homemate/recommend/dto/TopItemDto.java
+++ b/src/main/java/com/zerobase/homemate/recommend/dto/TopItemDto.java
@@ -1,9 +1,11 @@
 package com.zerobase.homemate.recommend.dto;
 
 
+import com.zerobase.homemate.entity.enums.Category;
+
 public record TopItemDto (
         String name,
-        String code,
+        Category category,
         Long count
 ){
 

--- a/src/main/java/com/zerobase/homemate/recommend/service/stats/ChoreStatsService.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/stats/ChoreStatsService.java
@@ -2,6 +2,8 @@ package com.zerobase.homemate.recommend.service.stats;
 
 
 import com.zerobase.homemate.entity.enums.Category;
+import com.zerobase.homemate.exception.CustomException;
+import com.zerobase.homemate.exception.ErrorCode;
 import com.zerobase.homemate.mission.service.MissionService;
 import com.zerobase.homemate.recommend.dto.TopItemDto;
 import com.zerobase.homemate.repository.CategoryChoreRepository;
@@ -11,7 +13,6 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -25,13 +26,9 @@ public class ChoreStatsService {
 
         // 1. Redis 집계 가져오기
         Map<String, Long> categoryCounts = redisChoreStatsService.getCategoryStats();
-        Map<String, Long> spaceCounts = redisChoreStatsService.getSpaceStats();
 
         // 2. Redis TOP N 정렬
-        List<String> topOverall = Stream.concat(
-                        categoryCounts.entrySet().stream(),
-                        spaceCounts.entrySet().stream()
-                )
+        List<String> topOverall = categoryCounts.entrySet().stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
                 .map(Map.Entry::getKey)
                 .toList();
@@ -42,7 +39,7 @@ public class ChoreStatsService {
         Long missionCount = (long) missionService.getMonthlyMissions(userId).size();
 
         // 3. 미션 카테고리 (Category.MISSIONS)
-        result.add(new TopItemDto(Category.MISSIONS.getCategoryName(), Category.MISSIONS.name(), missionCount));
+        result.add(new TopItemDto(Category.MISSIONS.getCategoryName(), Category.MISSIONS, missionCount));
 
         // 4. 나머지 TOP N
         topOverall.stream()
@@ -53,10 +50,10 @@ public class ChoreStatsService {
                         Category category = Category.valueOf(code);
                         String displayName = category.getCategoryName();
                         Long count = categoryChoreRepository.countByCategory(category);
-                        result.add(new TopItemDto(displayName, code, count));
+                        result.add(new TopItemDto(displayName, category, count));
                     } catch (IllegalArgumentException e) {
-                        // 해당되는 enum이 없을 경우 code를 그대로 노출시킨다.
-                        result.add(new TopItemDto(code, code, 0L));
+
+                        throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
                     }
                 });
 

--- a/src/test/java/com/zerobase/homemate/recommend/ChoreStatsServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/recommend/ChoreStatsServiceTest.java
@@ -1,5 +1,6 @@
 package com.zerobase.homemate.recommend;
 
+import com.zerobase.homemate.entity.enums.Category;
 import com.zerobase.homemate.mission.service.MissionService;
 import com.zerobase.homemate.recommend.dto.TopItemDto;
 import com.zerobase.homemate.recommend.service.stats.ChoreStatsService;
@@ -39,40 +40,44 @@ public class ChoreStatsServiceTest {
     @Test
     @DisplayName("미션 달성 집안일 우선순위 조회 + Top N 조회")
     void testGetTopOverallWithMissions() {
-
+        // given
         Long userId = 1L;
-        // given: Redis에 저장된 값 모킹
+
+        // Redis mock 데이터
         Map<String, Long> categoryCounts = Map.of(
                 "WINTER", 4L,
-                "FIFTEEN", 6L,
-                "SPRING", 3L,
-                "SUMMER", 5L,
-                "AUTUMN", 2L,
-                "EXTRA", 1L
-        );
-        Map<String, Long> spaceCounts = Map.of(
-                "ETC", 8L,
-                "KITCHEN", 2L
+                "SAFETY_CHECK", 6L,
+                "WEEKEND_WHOLE_ROUTINE", 3L,
+                "TEN_MINUTES_CLEANING", 5L,
+                "ETC", 2L,
+                "HOTEL_BATHROOM", 1L
         );
 
         when(redisChoreStatsService.getCategoryStats()).thenReturn(categoryCounts);
-        when(redisChoreStatsService.getSpaceStats()).thenReturn(spaceCounts);
 
         // when
-        List<TopItemDto> result = choreStatsService.getTopOverallWithMissions(userId, 5); // TopN = 5
+        List<TopItemDto> result = choreStatsService.getTopOverallWithMissions(userId, 5);
 
         // then
-        assertEquals(6, result.size()); // 총 5 + 1개 반환
+        assertEquals(6, result.size()); // 미션 + Top5
 
         // 첫 번째는 항상 미션
         assertEquals("미션 달성 집안일", result.get(0).name());
-        assertEquals("MISSIONS", result.get(0).code());
+        assertEquals(Category.MISSIONS, result.get(0).category());
 
-        // TopN 순서 검증 (미션 제외하고 상위 5개)
-        List<String> expectedCodes = List.of("ETC", "FIFTEEN", "SUMMER", "WINTER", "SPRING");
-        for (int i = 0; i < expectedCodes.size(); i++) {
-            assertEquals(expectedCodes.get(i), result.get(i + 1).code());
+        // TopN 순서 검증 (미션 제외)
+        List<Category> expectedCategories = List.of(
+                Category.SAFETY_CHECK,  // 6
+                Category.TEN_MINUTES_CLEANING,   // 5
+                Category.WINTER,   // 4
+                Category.WEEKEND_WHOLE_ROUTINE,   // 3
+                Category.ETC    // 2
+        );
+
+        for (int i = 0; i < expectedCategories.size(); i++) {
+            assertEquals(expectedCategories.get(i), result.get(i + 1).category());
         }
     }
+
 
 }

--- a/src/test/java/com/zerobase/homemate/recommend/RecommendControllerTest.java
+++ b/src/test/java/com/zerobase/homemate/recommend/RecommendControllerTest.java
@@ -1,10 +1,8 @@
 package com.zerobase.homemate.recommend;
 
 import com.zerobase.homemate.auth.security.UserPrincipal;
-import com.zerobase.homemate.entity.User;
+import com.zerobase.homemate.entity.enums.Category;
 import com.zerobase.homemate.entity.enums.Space;
-import com.zerobase.homemate.entity.enums.UserRole;
-import com.zerobase.homemate.entity.enums.UserStatus;
 import com.zerobase.homemate.recommend.controller.RecommendController;
 import com.zerobase.homemate.recommend.dto.SpaceChoreResponse;
 import com.zerobase.homemate.recommend.dto.TopItemDto;
@@ -18,14 +16,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
 import static org.mockito.Mockito.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -86,11 +82,11 @@ public class RecommendControllerTest {
 
 
         List<TopItemDto> topList = List.of(
-                new TopItemDto("미션 달성 집안일", "MISSIONS", 3L),
-                new TopItemDto("기타 집안일", "ETC", 8L),
-                new TopItemDto("15분 청소", "FIFTEEN", 6L),
-                new TopItemDto("겨울철 집안일", "WINTER", 4L),
-                new TopItemDto("주방", "KITCHEN", 2L)
+                new TopItemDto("미션 달성 집안일", Category.MISSIONS, 3L),
+                new TopItemDto("기타 집안일", Category.ETC, 8L),
+                new TopItemDto("15분 청소", Category.WEEKEND_WHOLE_ROUTINE, 6L),
+                new TopItemDto("겨울철 집안일", Category.WINTER, 4L),
+                new TopItemDto("주방", Category.ETC, 2L)
         );
 
         when(choreStatsService.getTopOverallWithMissions(userId, 5))
@@ -105,10 +101,10 @@ public class RecommendControllerTest {
                 .andExpect(jsonPath("$[0].name").value("미션 달성 집안일"))
                 .andExpect(jsonPath("$[1].name").value("기타 집안일"))
                 .andExpect(jsonPath("$[2].name").value("15분 청소"))
-                // code 검증
-                .andExpect(jsonPath("$[0].code").value("MISSIONS"))
-                .andExpect(jsonPath("$[1].code").value("ETC"))
-                .andExpect(jsonPath("$[2].code").value("FIFTEEN"))
+                // category 검증 (code → category)
+                .andExpect(jsonPath("$[0].category").value("MISSIONS"))
+                .andExpect(jsonPath("$[1].category").value("ETC"))
+                .andExpect(jsonPath("$[2].category").value("WEEKEND_WHOLE_ROUTINE"))
                 // count 검증
                 .andExpect(jsonPath("$[0].count").value(3))
                 .andExpect(jsonPath("$[1].count").value(8))


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 월간 카테고리 조회 기능 O
- 응답 내용, name, code, count로 되어 있음.

### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- 월간 카테고리 조회하는 기능에서 code 부분으로 표시되고 있던 parameter가 FE에서 enum 값과 동일하게 표시되게 만들었음에도 불구하고 일치하지 않아 400 Error 발생하였음을 확인하였습니다.

- 원인은 code는 String 변수이기에 값의 형식이 맞지 않아서 값의 내용은 같더라도 값 자체가 다르기 때문에 이번 일이 벌어진 것으로 보입니다.

- code -> category로 변경되었습니다.
- 월간 카테고리 조회 로직에서 space 관련 로직이 남아있는 부분이 확인되어 이를 제거 및 리팩토링 진행했습니다.

- API 명세서에도 갱신해놓았으니 참고 부탁 드리겠습니다.

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- code -> category로 변경되었습니다.
- 월간 카테고리 조회 로직에서 space 관련 로직이 남아있는 부분이 확인되어 이를 제거 및 리팩토링 진행했습니다.


## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 
<img width="440" height="665" alt="image" src="https://github.com/user-attachments/assets/5d6a4647-7ea2-44c3-b839-2146419e8fe0" />
카테고리 조회 기능 결과 API