### PR TITLE
[feat] 집안일 완료 및 날짜별 집안일 조회 시 팩터 추가 #181

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/dto/ChoreInstanceDto.java
+++ b/src/main/java/com/zerobase/homemate/chore/dto/ChoreInstanceDto.java
@@ -2,6 +2,7 @@ package com.zerobase.homemate.chore.dto;
 
 import com.zerobase.homemate.entity.ChoreInstance;
 import com.zerobase.homemate.entity.enums.ChoreStatus;
+import com.zerobase.homemate.entity.enums.RegistrationType;
 import com.zerobase.homemate.entity.enums.RepeatType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,6 +27,7 @@ public class ChoreInstanceDto {
         private ChoreStatus choreStatus;
         private RepeatType repeatType;
         private Integer repeatInterval;
+        private RegistrationType registrationType;
         private LocalDateTime completedAt;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
@@ -40,6 +42,7 @@ public class ChoreInstanceDto {
                 .choreStatus(choreInstance.getChoreStatus())
                 .repeatType(choreInstance.getChore().getRepeatType())
                 .repeatInterval(choreInstance.getChore().getRepeatInterval())
+                .registrationType(choreInstance.getChore().getRegistrationType())
                 .completedAt(choreInstance.getCompletedAt())
                 .createdAt(choreInstance.getCreatedAt())
                 .updatedAt(choreInstance.getUpdatedAt())


### PR DESCRIPTION
## 📝 계획
### 기존 상태
### 변경 후 상태
- 집안일 인스턴스 값 반환하는 API 의 응답 값에 집안일 추가 경로 팩터 추가

## 💡PR에서 핵심적으로 변경된 사항
- ```ChoreInstanceDto``` : ```registrationType``` 값 추가

## 📢이외 추가 변경 부분 및 기타
## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 
# 포스트맨 테스트
- 집안일 완료
<img width="788" height="802" alt="image" src="https://github.com/user-attachments/assets/cd15e005-9336-4d62-9b83-0b9f299e6302" />

- 날짜별 집안일 조회
<img width="791" height="791" alt="image" src="https://github.com/user-attachments/assets/c0133372-669b-4624-9e0c-156f29574f0c" />
