### PR TITLE
[fix] Badge Service 달성도 진행 개선 - 등록형 미션에 대한 로직 추가

### DIFF
--- a/src/main/java/com/zerobase/homemate/recommend/service/CategoryChoreCreator.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/CategoryChoreCreator.java
@@ -1,5 +1,6 @@
 package com.zerobase.homemate.recommend.service;
 
+import com.zerobase.homemate.badge.service.BadgeService;
 import com.zerobase.homemate.badge.service.UserBadgeStatsService;
 import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.entity.*;
@@ -40,6 +41,7 @@ public class CategoryChoreCreator {
     private final MissionService missionService;
     private final UserBadgeStatsService userBadgeStatsService;
     private final ApplicationEventPublisher eventPublisher;
+    private final BadgeService badgeService;
 
     @Transactional
     public ChoreDto.ApiResponse<ChoreDto.Response> createChoreFromCategory(Long userId,
@@ -109,6 +111,13 @@ public class CategoryChoreCreator {
                 missionService.increaseMissionCountForAction(userId,
                                 UserActionType.CREATE_CHORE_RECOMMENDED)
                         .stream().filter(MissionDto.Response::isCompleted).toList();
+
+
+        if(!userMission.isEmpty()){
+            for (MissionDto.Response mission : userMission) {
+                badgeService.evaluateBadgesMission(user);
+            }
+        }
 
         userBadgeStatsService.incrementTotalRegistered(userId);
 

--- a/src/main/java/com/zerobase/homemate/recommend/service/SpaceChoreCreator.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/SpaceChoreCreator.java
@@ -1,5 +1,6 @@
 package com.zerobase.homemate.recommend.service;
 
+import com.zerobase.homemate.badge.service.BadgeService;
 import com.zerobase.homemate.badge.service.UserBadgeStatsService;
 import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.entity.*;
@@ -40,6 +41,7 @@ public class SpaceChoreCreator {
     private final MissionService missionService;
     private final UserBadgeStatsService userBadgeStatsService;
     private final ApplicationEventPublisher eventPublisher;
+    private final BadgeService badgeService;
 
     @Transactional
     public ChoreDto.ApiResponse<ChoreDto.Response> createChoreFromSpace(Long userId,
@@ -104,6 +106,12 @@ public class SpaceChoreCreator {
                 missionService.increaseMissionCountForAction(userId,
                                 UserActionType.CREATE_CHORE_WITH_SPACE)
                         .stream().filter(MissionDto.Response::isCompleted).toList();
+
+        if(!userMission.isEmpty()){
+            for (MissionDto.Response mission : userMission) {
+                badgeService.evaluateBadgesMission(user);
+            }
+        }
 
         userBadgeStatsService.incrementTotalRegistered(userId);
 


### PR DESCRIPTION


<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 완료형 미션들에만 뱃지 Service Increment + evaluate 로직이 작용되고 있는 상태입니다.
-
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- CREATE_CHORE_WITH_SPACE, CREATE_CHORE_RECOMMEND으로 인해 등록형 미션이 완료될 경우, userMission에서 출력되는 횟수만큼 뱃지의 missionCount가 증가되도록 수정하였습니다.
-
- 테스트는 통합 테스트 + Logger 평가로 진행하였습니다!
## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- Badge 이슈 중 미션을 달성했는데도 달성도가 올라가지 않았던 이유 -> 등록형 미션에는 Badge Logic의 부재였습니다.

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [] API 테스트

<img width="1346" height="103" alt="image" src="https://github.com/user-attachments/assets/86348871-376e-4043-ae8b-497b48c285be" />
CREATE_CHORE_WITH_SPACE 미션 달성 시 미션 달성 여부 확인 및 badge 평가 로직 작동 Log

<img width="1351" height="105" alt="image" src="https://github.com/user-attachments/assets/dc5fa666-b685-495f-90f4-4eb336e73727" />
CREATE_CHORE_RECOMMEND 미션 달성 시 미션 달성 여부 확인 및 badge 평가 로직 작동 Log
 