### PR TITLE
[fix] 미션 달성 집안일 서브 텍스트 불일치 수정

### DIFF
--- a/src/main/java/com/zerobase/homemate/badge/service/BadgeService.java
+++ b/src/main/java/com/zerobase/homemate/badge/service/BadgeService.java
@@ -156,11 +156,6 @@ public class BadgeService {
 
             BadgeProgressResponse dto = BadgeProgressResponse.of(type, (int) currentCount, acquired, acquiredAt);
             all.add(dto);
-
-            log.info(
-                    "Badge: {}, acquired: {}, acquiredAt: {}, currentCount: {}, requiredCount: {}, remainingCount: {}",
-                    type, acquired, acquiredAt, dto.currentCount(), dto.requiredCount(), dto.remainingCount()
-            );
         }
 
         all.sort(Comparator.comparing(BadgeProgressResponse::acquired).reversed()
@@ -185,12 +180,7 @@ public class BadgeService {
                     boolean isAcquired = badge != null;
                     LocalDateTime acquiredAt = isAcquired ? badge.getAcquiredAt() : null;
 
-                    BadgeProgressResponse dto = BadgeProgressResponse.of(type, currentCount, isAcquired, acquiredAt);
-                    log.info(
-                            "ClosestBadge candidate - Badge: {}, acquired: {}, acquiredAt: {}, currentCount: {}, requiredCount: {}, remainingCount: {}",
-                            type, isAcquired, acquiredAt, dto.currentCount(), dto.requiredCount(), dto.remainingCount()
-                    );
-                    return dto;
+                    return BadgeProgressResponse.of(type, currentCount, isAcquired, acquiredAt);
                 })
                 .filter(b -> !b.acquired()) // 아직 획득하지 않은 배지만
                 .sorted(Comparator.comparingInt(BadgeProgressResponse::remainingCount)) // 남은 횟수 적은 순

--- a/src/main/java/com/zerobase/homemate/recommend/service/CategoryService.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/CategoryService.java
@@ -19,6 +19,7 @@ import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class CategoryService {
 
     private final CategoryChoreRepository categoryChoreRepository;
@@ -66,6 +68,10 @@ public class CategoryService {
                 category,
                 Pageable.ofSize(DEFAULT_PAGE_SIZE)
         );
+
+        // 조회된 개수 로그 추가
+        log.info("getChoresByCategory - category: {}, fetched size: {}",
+                category, randomChores.size());
 
         return randomChores.stream()
                 .sorted(Comparator.comparingInt(categoryChore -> REPEAT_PRIORITY.get(categoryChore.getRepeatType())))

--- a/src/main/java/com/zerobase/homemate/recommend/service/stats/ChoreStatsService.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/stats/ChoreStatsService.java
@@ -1,26 +1,32 @@
 package com.zerobase.homemate.recommend.service.stats;
 
 
+import com.zerobase.homemate.entity.Mission;
 import com.zerobase.homemate.entity.enums.Category;
+import com.zerobase.homemate.entity.enums.MissionType;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.ErrorCode;
-import com.zerobase.homemate.mission.service.MissionService;
 import com.zerobase.homemate.recommend.dto.TopItemDto;
 import com.zerobase.homemate.repository.CategoryChoreRepository;
+import com.zerobase.homemate.repository.MissionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChoreStatsService {
 
     private final RedisChoreStatsService redisChoreStatsService;
     private final CategoryChoreRepository categoryChoreRepository;
-    private final MissionService missionService;
+    private final MissionRepository missionRepository;
 
     public List<TopItemDto> getTopOverallWithMissions(Long userId){
 
@@ -35,11 +41,21 @@ public class ChoreStatsService {
 
         List<TopItemDto> result = new ArrayList<>();
 
+        List<Mission> monthlyMissions =
+                missionRepository.findByActiveYearMonthAndIsActiveTrueOrderByIdAsc(YearMonth.now());
+
+
         // 미션 집안일 수
-        Long missionCount = (long) missionService.getMonthlyMissions(userId).size();
+        Long missionCount = monthlyMissions.stream()
+                .filter(mission -> CHORE_MISSION_TYPES.contains(mission.getMissionType()))
+                .count();
+
 
         // 3. 미션 카테고리 (Category.MISSIONS)
         result.add(new TopItemDto(Category.MISSIONS.getCategoryName(), Category.MISSIONS, missionCount));
+
+        log.info("Mission Category Added : {}", missionCount);
+
 
         // 4. 나머지 TOP N
         topOverall.stream()
@@ -58,4 +74,9 @@ public class ChoreStatsService {
 
         return result;
     }
+
+    private static final Set<MissionType> CHORE_MISSION_TYPES = Set.of(
+            MissionType.CHORE,
+            MissionType.MONTHLY_CHORE
+    );
 }

--- a/src/test/java/com/zerobase/homemate/recommend/ChoreStatsServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/recommend/ChoreStatsServiceTest.java
@@ -1,11 +1,11 @@
 package com.zerobase.homemate.recommend;
 
 import com.zerobase.homemate.entity.enums.Category;
-import com.zerobase.homemate.mission.service.MissionService;
 import com.zerobase.homemate.recommend.dto.TopItemDto;
 import com.zerobase.homemate.recommend.service.stats.ChoreStatsService;
 import com.zerobase.homemate.recommend.service.stats.RedisChoreStatsService;
 import com.zerobase.homemate.repository.CategoryChoreRepository;
+import com.zerobase.homemate.repository.MissionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,18 +22,18 @@ public class ChoreStatsServiceTest {
     private RedisChoreStatsService redisChoreStatsService;
     private ChoreStatsService choreStatsService;
     private CategoryChoreRepository categoryChoreRepository;
-    private MissionService missionService;
+    private MissionRepository missionRepository;
 
     @BeforeEach
     void setUp() {
         redisChoreStatsService = mock(RedisChoreStatsService.class);
         categoryChoreRepository = mock(CategoryChoreRepository.class);
-        missionService = mock(MissionService.class);
+        missionRepository = mock(MissionRepository.class);
 
         choreStatsService = new ChoreStatsService(
                 redisChoreStatsService,
                 categoryChoreRepository,
-                missionService
+                missionRepository
         );
     }
 


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 미션 달성 집안일에서 Mission Category에 있는 집안일의 수와 서브 텍스트로 출력되는 집안일의 수가 불일치하는 이슈가 발생했습니다.
- 원인은 getTopOverallWithMissions에서 count를 셀 때 따로 필터 로직이 부재하였기 때문으로 밝혀졌습니다. 

### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- 이를 보강하기 위해 MissionType 기준으로 Filter를 작성하였습니다.
- MissionType은 userMission에서는 가져올 수 없어서 MissionRepository에 있는 활성화된 미션 기준으로 가져와서 필터 로직을 적용하는 것으로 바꾸었습니다.
- Filter는 현재는 USER_ACTION만 제외하는 Filter를 적용하였습니다.
- 금번 Issue와는 별도로 Badge List 전체를 띄우는 Log는 삭제했습니다.

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- getTopOverallWithMissions에서 MissionType.USER_ACTION인 미션은 missionCount에서 카운트되지 않도록 변경했습니다.
- BadgeList, Closest Badge List 조회 시, Badge 전체 List가 나오는 log 삭제.

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
<img width="454" height="461" alt="image" src="https://github.com/user-attachments/assets/219b11b3-5a3b-44cf-ba8e-7ce15319d52a" />
기존 API 출력 화면
(현재 기준은 월간 미션처럼 12월의 미션 3가지를 추가한 상태에서 API 평가가 진행되었습니다. -> 3개가 나와서 FE의 로직으로 3개의 집안일이라고 표시하는 것을 재현할 수 있습니다.)

<img width="453" height="454" alt="image" src="https://github.com/user-attachments/assets/5a45908f-4766-4110-aead-bd2dfe5cbb3d" />
변경 후 API 화면, USERACTION Type은 나타나지 않고 있음.
<img width="369" height="334" alt="image" src="https://github.com/user-attachments/assets/79a70320-876b-4f7f-bc47-243592a14fdd" />
MISSIONS에 해당되는 Chores를 조회할 때 나오는 2가지 집안일처럼 count가 정상적으로 2개로 되고 있음.

 