### PR TITLE
[fix] 미션 달성도 카운팅 로직 수정

### DIFF
--- a/src/main/java/com/zerobase/homemate/mission/service/MissionService.java
+++ b/src/main/java/com/zerobase/homemate/mission/service/MissionService.java
@@ -180,8 +180,9 @@ public class MissionService {
 
         return switch (type) {
             case COMPLETE_ANY_CHORE -> true;
-            case COMPLETE_CHORE -> choreRegistrationType == RegistrationType.CATEGORY
-            && qualifiesChoreTitle(missionTitle, choreTitle);
+            case COMPLETE_CHORE -> (choreRegistrationType == RegistrationType.CATEGORY
+                || choreRegistrationType == RegistrationType.SPACE)
+                && qualifiesChoreTitle(missionTitle, choreTitle);
             case COMPLETE_CHORE_WITH_SPACE -> choreRegistrationType == RegistrationType.SPACE
                 && missionSpace.equals(choreSpace);
             default -> false;


### PR DESCRIPTION
## 📝 계획
### 기존 상태
- 추천 카테고리 내 미션 달성 집안일의 집안일로 추가된 집안일 완료/해제 시에만 미션 달성도 증감

### 변경 후 상태
- 추천 카테고리 및 추천 공간 집안일에서 추가된 미션 관련 집안일 완료/해제 시에도 미션 달성도 증감 반영

## 💡PR에서 핵심적으로 변경된 사항
- ```MissionService``` : ```COMPLETE_CHORE``` type 의 경우 ```RegistrationType.SPACE``` 조건 추가

## 📢이외 추가 변경 부분 및 기타
## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 