### PR TITLE
[feat] 회원탈퇴시 FCM 토큰 삭제 로직 추가

### DIFF
--- a/src/main/java/com/zerobase/homemate/auth/service/AuthService.java
+++ b/src/main/java/com/zerobase/homemate/auth/service/AuthService.java
@@ -10,6 +10,7 @@ import com.zerobase.homemate.entity.UserSocialAccount;
 import com.zerobase.homemate.entity.WithdrawLog;
 import com.zerobase.homemate.exception.CustomException;
 import com.zerobase.homemate.exception.ErrorCode;
+import com.zerobase.homemate.notification.push.service.FcmTokenService;
 import com.zerobase.homemate.repository.UserRepository;
 import com.zerobase.homemate.repository.UserSocialAccountRepository;
 import com.zerobase.homemate.repository.WithdrawLogRepository;
@@ -32,6 +33,8 @@ public class AuthService {
     private final TokenRefreshPolicy tokenRefreshPolicy;
     private final WithdrawLogRepository withdrawLogRepository;
     private final UserSocialAccountRepository userSocialAccountRepository;
+
+    private final FcmTokenService fcmTokenService;
 
     public TokenResponseDto.AuthTokenCreatedDto refresh(String refreshToken) {
         Claims claims = jwtService.parseAndValidateType(refreshToken, "RT");
@@ -91,6 +94,7 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.withdraw();
+        fcmTokenService.deleteAllToken(user);
 
         UserSocialAccount userSocialAccount = userSocialAccountRepository.findByUser(user)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/zerobase/homemate/notification/push/service/FcmTokenService.java
+++ b/src/main/java/com/zerobase/homemate/notification/push/service/FcmTokenService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -64,5 +65,11 @@ public class FcmTokenService {
     @Transactional
     public void deactivateToken(FcmTokenDto.Request request) {
         fcmTokenRepository.findByToken(request.getToken()).ifPresent(FcmToken::deactivate);
+    }
+
+    @Transactional
+    public void deleteAllToken(User user) {
+        List<FcmToken> list = fcmTokenRepository.findAllByUserAndIsActiveTrue(user);
+        list.forEach(FcmToken::deactivate);
     }
 }


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

-
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- 회원탈퇴시 FCM 토큰 비활성화 -> 알림 구독 정보 삭제

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

- `FcmTokenService`: `deleteAllToken()` 메서드 추가
- `AuthService`: `withdraw()` 메서드에 `deleteAllToken()` 호출 추가

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 