### PR TITLE
[feat] 집안일 상세조회 기능 분리 : choreId/choreInstanceId

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -57,12 +57,24 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @GetMapping("/{choreInstanceId}")
+    @GetMapping("/{choreId}")
     public ResponseEntity<ChoreDto.Response> getChore(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long choreId) {
+
+        ChoreDto.Response response =
+                choreService.getChoreByChoreId(user.id(), choreId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/instance/{choreInstanceId}")
+    public ResponseEntity<ChoreDto.Response> getChoreInstance(
         @AuthenticationPrincipal UserPrincipal user,
         @PathVariable Long choreInstanceId) {
 
-        ChoreDto.Response response = choreService.getChore(user.id(), choreInstanceId);
+        ChoreDto.Response response =
+                choreService.getChoreByInstanceId(user.id(), choreInstanceId);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -287,7 +287,24 @@ public class ChoreService {
         return startDate.isAfter(endDate);
     }
 
-    public ChoreDto.Response getChore(Long userId, Long choreInstanceId) {
+    public ChoreDto.Response getChoreByChoreId(Long userId, Long choreId) {
+
+        Chore chore = choreRepository.findById(choreId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHORE_NOT_FOUND));
+
+        if (!chore.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if (chore.getIsDeleted()) {
+            throw new CustomException(ErrorCode.CHORE_ALREADY_DELETED);
+        }
+
+        return ChoreDto.Response.fromEntity(chore);
+    }
+
+    public ChoreDto.Response getChoreByInstanceId(
+            Long userId, Long choreInstanceId) {
 
         ChoreInstance choreInstance =
             choreInstanceRepository.findById(choreInstanceId)

--- a/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
@@ -6,7 +6,6 @@ import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
 import com.zerobase.homemate.entity.enums.ChoreStatus;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
## 📝 계획
### 기존 상태
- 집안일 상세 조회 시 ```choreInstanceId``` 사용

### 변경 후 상태
- 집안일 상세 조회 API 분리
  - ```choreId``` / ```choreInstanceId``` 사용해서 조회 가능

## 💡PR에서 핵심적으로 변경된 사항
- ```ChoreService``` : ```getChoreByChoreId()``` 추가, 기존 ```getChore()``` 메서드명 변경

## 📢이외 추가 변경 부분 및 기타
## ✅ 테스트
- [ ] 테스트 코드
- [X] API 테스트 
## 포스트맨 테스트
- choreId = 5 로 조회
<img width="804" height="664" alt="image" src="https://github.com/user-attachments/assets/8f9931fd-6ed3-4def-a7e8-2bb3c8183dd5" />
- choreInstanceId = 13 으로 조회
<img width="807" height="665" alt="image" src="https://github.com/user-attachments/assets/1b08044a-4732-4ad4-873a-197c35e37dd4" />
