### PR TITLE
[refactor] 월간 카테고리 조회 로직 페이지 기능 제거

### DIFF
--- a/src/main/java/com/zerobase/homemate/recommend/service/CategoryQueryService.java
+++ b/src/main/java/com/zerobase/homemate/recommend/service/CategoryQueryService.java
@@ -113,8 +113,7 @@ public class CategoryQueryService {
             List<CategoryChore> chores =
                     categoryChoreRepository.findActiveByCategoriesAndCategoryType(
                             categories,
-                            CategoryType.MONTHLY,
-                            Pageable.ofSize(DEFAULT_PAGE_SIZE)
+                            CategoryType.MONTHLY
                     );
 
             return chores.stream()
@@ -127,8 +126,7 @@ public class CategoryQueryService {
                 categoryChoreRepository.findActiveByCategoryTypeAndSubCategory(
                         categories,
                         CategoryType.MONTHLY,
-                        subCategory,
-                        Pageable.ofSize(DEFAULT_PAGE_SIZE)
+                        subCategory
                 );
 
         return chores.stream()

--- a/src/main/java/com/zerobase/homemate/repository/CategoryChoreRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/CategoryChoreRepository.java
@@ -17,14 +17,6 @@ import java.util.List;
 
 public interface CategoryChoreRepository extends JpaRepository<CategoryChore, Long> {
 
-    @Query("""
-    SELECT c
-    from CategoryChore c
-    WHERE c.category = :category
-    ORDER BY function('RAND')
-""")
-    List<CategoryChore> findByCategory(@Param("category") Category category, Pageable pageable);
-
     List<CategoryChore> findAllByTitle(String titleKo);
 
     Long countByCategory(Category category);
@@ -92,8 +84,7 @@ public interface CategoryChoreRepository extends JpaRepository<CategoryChore, Lo
 """)
     List<CategoryChore> findActiveByCategoriesAndCategoryType(
             @Param("categories") Categories categories,
-            @Param("categoryType") CategoryType categoryType,
-            Pageable pageable
+            @Param("categoryType") CategoryType categoryType
     );
 
 
@@ -108,14 +99,11 @@ WHERE cc.categories = :categories
     List<CategoryChore> findActiveByCategoryTypeAndSubCategory(
             @Param("categories") Categories categories,
             @Param("categoryType") CategoryType categoryType,
-            @Param("subCategory") SubCategory subCategory,
-            Pageable pageable
+            @Param("subCategory") SubCategory subCategory
     );
 
 
 
 
     long countBySeasonAndCategoryType(Season currentSeason, CategoryType categoryType);
-
-    long countByCategories(Categories selected);
 }

--- a/src/test/java/com/zerobase/homemate/recommend/CategoryQueryServiceTest.java
+++ b/src/test/java/com/zerobase/homemate/recommend/CategoryQueryServiceTest.java
@@ -148,8 +148,7 @@ public class CategoryQueryServiceTest {
 
         given(categoryChoreRepository.findActiveByCategoriesAndCategoryType(
                 eq(categories),
-                eq(CategoryType.MONTHLY),
-                any(Pageable.class)
+                eq(CategoryType.MONTHLY)
         )).willReturn(List.of(testMonthChore));
 
         // when


### PR DESCRIPTION
- FE & 기획 팀의 요청으로 월간 카테고리 조회 시에 6개씩 리스트화하여 집안일을 조회할 수 있게 해주던 기능에서 갯수 제한을 해제합니다.

- 사용하지 않는 Method들 정리했습니다.

<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 기존에는 월간 카테고리 시 해당되는 카테고리 안에 있는 집안일 6개만 List 형태로 조회되게 만들었습니다.
-
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- Repository, Service 코드에서 6개를 한정짓는 기능을 제거했습니다.
- Repository 계층에서는 Page기능을 제거했습니다.
- Service 계층에서는 limit 기능을 제거했습니다.
- 계절별 집안일, 고정 카테고리에 속하는 집안일 조회 시에는 6개씩 한정짓는 기능은 유지됩니다.

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

-

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 