### PR TITLE
[refactor] 뱃지 Image 기본적인 주소 변경(테스트 서버, 본 운영 서버 분기 로직 작성)

### DIFF
--- a/src/main/java/com/zerobase/homemate/entity/enums/BadgeType.java
+++ b/src/main/java/com/zerobase/homemate/entity/enums/BadgeType.java
@@ -2,9 +2,12 @@ package com.zerobase.homemate.entity.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 
 @Getter
 @RequiredArgsConstructor
+@Slf4j
 public enum BadgeType {
 
     START_HALF( "시작이 반", "아무 집안일 1회 완료",  null,  null, 1, BadgeCategory.ALL, null,"start_half.png"),
@@ -87,14 +90,20 @@ public enum BadgeType {
     private final TimeSlot timeSlot;
     private final String imageName;
 
-    private static final String BASE_URL = "https://homemate.io.kr/test/badges/";
+    private static final String BASE_URL = "https://homemate.io.kr";
 
-    public String getBadgeImageUrl(){
+    @Value("${auth.dev.enabled:false}")
+    private boolean devEnabled;
 
-        String url = BASE_URL + imageName;
-        System.out.println("[BadgeType] getBadgeImageUrl : " + this.imageName + "->" + url);
+    public String getBadgeImageUrl() {
+        String url = devEnabled
+                ? BASE_URL + "/test/badges/"
+                : BASE_URL + "/badges/";
 
-        return BASE_URL + imageName;
+        log.info("[BadgeImageUrl] devEnabled={}, badgeImageUrl={}", devEnabled, url);
+
+        return url;
     }
+
 
 }


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->
- 현재 badgeImageUrl 기본 : https://homemate.io.kr/badges/
- nginx에서 테스트 서버는 https://homemate.io.kr/test/badges/로 라우팅이 되고 있고,
- 본 운영 서버는 https://homemate.io.kr/badges/로 라우팅이 되고 있는 점을 확인했습니다.

### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->
- 이에 따라 auth.dev.enabled값에 따라 분기하도록 코드를 변경하였습니다! 
- auth.dev.enabled = true 시, 테스트 서버 -> https://homemate.io.kr/test/badges/
- false 시, 본 운영 서버 -> https://homemate.io.kr/badges/ 로  지정됩니다.
- 만약, auth.dev.enabled 값이 없을 경우, 자동으로 본 운영 서버로 간주됩니다.

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->
- badgeImageUrl을 생성하는 기본 값인 BASE_URL 값의 변경입니다.
-

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
-
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 