### PR TITLE
[fix] 캘린더 집안일 삭제하기 기능 롤백 및 리스트 집안일 삭제하기 기능 수정 #230

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -105,10 +105,9 @@ public class ChoreController {
     @DeleteMapping("/{choreId}")
     public ResponseEntity<Void> deleteChore(
         @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable Long choreId,
-        @RequestParam boolean applyToAfter) {
+        @PathVariable Long choreId) {
 
-        choreService.deleteChore(user.id(), choreId, applyToAfter);
+        choreService.deleteChore(user.id(), choreId);
 
         return ResponseEntity.noContent().build();
     }
@@ -116,9 +115,10 @@ public class ChoreController {
     @DeleteMapping("/instance/{choreInstanceId}")
     public ResponseEntity<Void> deleteChoreInstance(
             @AuthenticationPrincipal UserPrincipal user,
-            @PathVariable Long choreInstanceId) {
+            @PathVariable Long choreInstanceId,
+            @RequestParam boolean applyToAfter) {
 
-        choreService.deleteChoreInstance(user.id(), choreInstanceId);
+        choreService.deleteChoreInstance(user.id(), choreInstanceId, applyToAfter);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
+++ b/src/main/java/com/zerobase/homemate/chore/service/ChoreService.java
@@ -23,6 +23,7 @@ import com.zerobase.homemate.repository.UserNotificationSettingRepository;
 import com.zerobase.homemate.repository.UserRepository;
 import com.zerobase.homemate.util.ChoreInstanceGenerator;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 
@@ -366,7 +367,7 @@ public class ChoreService {
     }
 
     @Transactional
-      public void deleteChore(Long userId, Long choreId, boolean applyToAfter) {
+      public void deleteChore(Long userId, Long choreId) {
 
         Chore chore = choreRepository.findById(choreId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CHORE_NOT_FOUND));
@@ -375,20 +376,16 @@ public class ChoreService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
-        if (applyToAfter) {
-            chore.setEndDate(choreInstanceRepository.findBeforeDueDateByChore(chore));
-            choreInstanceRepository.bulkSoftDeleteAfterByChore(chore);
-            softDeleteChoreIfAllInstancesDeleted(chore);
-        } else {
-            List<ChoreInstance> instances = chore.getChoreInstances();
-            instances.forEach(ChoreInstance::softDelete);
-            chore.softDelete();
+        if (chore.getIsDeleted()) {
+            throw new CustomException(ErrorCode.CHORE_ALREADY_DELETED);
         }
+
+        chore.softDelete();
+        choreInstanceRepository.bulkSoftDeleteAfterByChore(chore);
     }
 
     @Transactional
-    public void deleteChoreInstance(Long userId, Long choreInstanceId) {
-
+    public void deleteChoreInstance(Long userId, Long choreInstanceId, boolean applyToAfter) {
         ChoreInstance choreInstance =
                 choreInstanceRepository.findById(choreInstanceId)
                         .orElseThrow(() -> new CustomException(ErrorCode.CHORE_INSTANCE_NOT_FOUND));
@@ -401,14 +398,35 @@ public class ChoreService {
         if (choreInstance.getChoreStatus() == ChoreStatus.DELETED) {
             throw new CustomException(ErrorCode.CHORE_INSTANCE_ALREADY_DELETED);
         }
+        if (choreInstance.getChoreStatus() == ChoreStatus.PENDING ||
+                choreInstance.getChoreStatus() == ChoreStatus.COMPLETED) {
+            if (chore.getRepeatType() == RepeatType.NONE ||
+                    chore.getStartDate().equals(chore.getEndDate())) {
+                choreInstance.softDelete();
+                chore.softDelete();
+            } else {
+                if (applyToAfter) {
+                    if (!choreInstance.getDueDate().equals(chore.getStartDate())) {
+                        setStartDateEndDateForCase(chore, choreInstance, applyToAfter);
+                    }
+                    choreInstanceRepository.bulkSoftDeleteAfterByChoreAndStatuses(
+                            chore, choreInstance.getDueDate(),
+                            ChoreStatus.DELETED, LocalDateTime.now());
+                } else {
+                    setStartDateEndDateForCase(chore, choreInstance, applyToAfter);
+                    choreInstance.softDelete();
+                }
+            }
 
-        setStartDateEndDateForCase(chore, choreInstance);
-        choreInstance.softDelete();
-        softDeleteChoreIfAllInstancesDeleted(chore);
+            softDeleteChoreIfAllInstancesDeleted(chore);
+        } else {
+            throw new CustomException(ErrorCode.CHORE_ALREADY_DELETED);
+        }
+
     }
 
     private void setStartDateEndDateForCase(
-        Chore chore, ChoreInstance choreInstance) {
+            Chore chore, ChoreInstance choreInstance, boolean applyToAfter) {
         EnumSet<ChoreStatus> includedStatuses =
             EnumSet.of(ChoreStatus.PENDING, ChoreStatus.COMPLETED);
         if (choreInstance.getDueDate().equals(chore.getStartDate())) {
@@ -418,7 +436,7 @@ public class ChoreService {
                                     chore, choreInstance.getDueDate(), includedStatuses);
 
             nextChore.ifPresent(instance -> chore.setStartDate(instance.getDueDate()));
-        } else if (choreInstance.getDueDate().equals(chore.getEndDate())) {
+        } else if (choreInstance.getDueDate().equals(chore.getEndDate()) || applyToAfter) {
             Optional<ChoreInstance> beforeChore =
                     choreInstanceRepository.
                             findFirstByChoreAndDueDateLessThanAndChoreStatusInOrderByDueDateDesc(

--- a/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
+++ b/src/main/java/com/zerobase/homemate/repository/ChoreInstanceRepository.java
@@ -6,6 +6,8 @@ import com.zerobase.homemate.entity.Chore;
 import com.zerobase.homemate.entity.ChoreInstance;
 import com.zerobase.homemate.entity.enums.ChoreStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -50,10 +52,24 @@ public interface ChoreInstanceRepository extends JpaRepository<ChoreInstance, Lo
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE ChoreInstance ci
+           SET ci.choreStatus = :deleted,
+               ci.deletedAt = :now
+         WHERE ci.chore = :chore
+           AND ci.choreStatus IN ('PENDING', 'COMPLETED')
+           AND ci.dueDate >= :dueDate
+    """)
+    void bulkSoftDeleteAfterByChoreAndStatuses(
+            @Param("chore") Chore chore,
+            @Param("dueDate") LocalDate dueDate,
+            @Param("deleted") ChoreStatus deleted,
+            @Param("now") LocalDateTime now);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE ChoreInstance ci
            SET ci.choreStatus = com.zerobase.homemate.entity.enums.ChoreStatus.DELETED,
                ci.deletedAt = CURRENT_TIMESTAMP
          WHERE ci.chore = :chore
-           AND ci.dueDate >= CURRENT_DATE
     """)
     void bulkSoftDeleteAfterByChore(@Param("chore") Chore chore);
 


### PR DESCRIPTION
## 📝 계획
### 기존 상태
- 리스트 집안일 삭제하기 (전체/오늘 이후)
- 캘린더 집안일 인스턴스 삭제하기

### 변경 후 상태
- 기획팀 요청으로 배포 일정에 맞춰 기존 캘린더 삭제 로직 복구했습니다.
- 캘린더 집안일 삭제하기 (이 일정만 삭제/향후 일정 삭제)
- 리스트 집안일 삭제하기 (전체 삭제)

## 💡PR에서 핵심적으로 변경된 사항
- ```ChoreService``` : ```deleteChore()``` 메서드 단순 삭제만 진행, ```deleteChoreInstance()``` 메서드 단일/향후 일정 삭제 가능하도록 변경 
- ```ChoreRepository``` : 삭제했던 ```bulkSoftDeleteAfterByChoreAndStatuses()``` 메서드 복구, ```bulkSoftDeleteAfterByChore()``` 메서드 `오늘 이후` 조건 삭제

## 📢이외 추가 변경 부분 및 기타
## ✅ 테스트
- [X] 테스트 코드
- [ ] API 테스트 

### 포스트맨 테스트
- 리스트 집안일 삭제하기
<img width="710" height="545" alt="image" src="https://github.com/user-attachments/assets/d052c282-d50d-4de0-ab78-926bbec2889e" />

- 캘린더 집안일 삭제하기 (이 일정만 삭제 & 시작일 삭제 -> 시작일 변경)
<img width="716" height="540" alt="image" src="https://github.com/user-attachments/assets/d8404ae0-1e91-4877-b7e6-eebe50ce93d4" />

- 캘린더 집안일 삭제하기 (이 일정만 삭제 & 종료일 삭제 -> 종료일 변경)
<img width="718" height="427" alt="image" src="https://github.com/user-attachments/assets/f141e524-d37e-4cf4-8406-8511c7324bb8" />

- 캘린더 집안일 삭제하기 (향후 일정 삭제 -> 잔여 인스턴스 없음 -> 집안일 삭제)
<img width="716" height="418" alt="image" src="https://github.com/user-attachments/assets/f586befb-f7bc-44a8-9d3d-c5c767d90441" />
