### PR TITLE
[Refactor] 집안일 API 경로 조정

### DIFF
--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -17,13 +17,13 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/chore")
+@RequestMapping("/chores")
 @RequiredArgsConstructor
 public class ChoreController {
 
     private final ChoreService choreService;
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<ApiResponse<ChoreDto.Response>> createChore(
         @AuthenticationPrincipal UserPrincipal user,
         @Valid @RequestBody ChoreDto.CreateRequest request) {
@@ -34,7 +34,7 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{choreInstanceId}")
+    @PutMapping("/instances/{choreInstanceId}")
     public ResponseEntity<ApiResponse<ChoreDto.Response>> updateChore(
         @AuthenticationPrincipal UserPrincipal user,
         @PathVariable Long choreInstanceId,
@@ -46,7 +46,7 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PatchMapping("/{choreInstanceId}")
+    @PatchMapping("/instances/{choreInstanceId}/complete")
     public ResponseEntity<ApiResponse<ChoreInstanceDto.Response>> completeChore(
         @AuthenticationPrincipal UserPrincipal user,
         @PathVariable Long choreInstanceId) {
@@ -68,7 +68,7 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @GetMapping("/instance/{choreInstanceId}")
+    @GetMapping("/instances/{choreInstanceId}")
     public ResponseEntity<ChoreDto.Response> getChoreInstance(
         @AuthenticationPrincipal UserPrincipal user,
         @PathVariable Long choreInstanceId) {
@@ -112,7 +112,7 @@ public class ChoreController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/instance/{choreInstanceId}")
+    @DeleteMapping("/instances/{choreInstanceId}")
     public ResponseEntity<Void> deleteChoreInstance(
             @AuthenticationPrincipal UserPrincipal user,
             @PathVariable Long choreInstanceId,
@@ -123,13 +123,13 @@ public class ChoreController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/today-rate/{today}")
-    public ResponseEntity<Map<String, Double>> getTodayCompleteRate(
+    @GetMapping("/completion-rate/{date}")
+    public ResponseEntity<Map<String, Double>> getCompletionRate(
         @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable LocalDate today
+        @PathVariable LocalDate date
     ) {
 
-        double rate = choreService.getTodayCompleteRate(user.id(), today);
+        double rate = choreService.getTodayCompleteRate(user.id(), date);
 
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("rate", rate));
     }
@@ -151,3 +151,4 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.OK).body(chores);
     }
 }
+

--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreController.java
@@ -3,8 +3,6 @@ package com.zerobase.homemate.chore.controller;
 import com.zerobase.homemate.auth.security.UserPrincipal;
 import com.zerobase.homemate.chore.dto.ChoreDto;
 import com.zerobase.homemate.chore.dto.ChoreDto.ApiResponse;
-import com.zerobase.homemate.chore.dto.ChoreInstanceDto;
-import com.zerobase.homemate.chore.dto.ChoreInstanceDto.Response;
 import com.zerobase.homemate.chore.service.ChoreService;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -34,29 +32,6 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/instances/{choreInstanceId}")
-    public ResponseEntity<ApiResponse<ChoreDto.Response>> updateChore(
-        @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable Long choreInstanceId,
-        @Valid @RequestBody ChoreDto.UpdateRequest request) {
-
-        ApiResponse<ChoreDto.Response> response = choreService.updateChores(user.id(),
-            choreInstanceId, request);
-
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @PatchMapping("/instances/{choreInstanceId}/complete")
-    public ResponseEntity<ApiResponse<ChoreInstanceDto.Response>> completeChore(
-        @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable Long choreInstanceId) {
-
-        ApiResponse<ChoreInstanceDto.Response> response =
-            choreService.completeChore(user.id(), choreInstanceId);
-
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
     @GetMapping("/{choreId}")
     public ResponseEntity<ChoreDto.Response> getChore(
             @AuthenticationPrincipal UserPrincipal user,
@@ -68,26 +43,14 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @GetMapping("/instances/{choreInstanceId}")
-    public ResponseEntity<ChoreDto.Response> getChoreInstance(
-        @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable Long choreInstanceId) {
+    @DeleteMapping("/{choreId}")
+    public ResponseEntity<Void> deleteChore(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long choreId) {
 
-        ChoreDto.Response response =
-                choreService.getChoreByInstanceId(user.id(), choreInstanceId);
+        choreService.deleteChore(user.id(), choreId);
 
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @GetMapping("/instances")
-    public ResponseEntity<List<Response>> getChoreInstancesByDate(
-        @AuthenticationPrincipal UserPrincipal user,
-        @RequestParam LocalDate date) {
-
-        List<ChoreInstanceDto.Response> responses =
-            choreService.getChoreInstancesByDate(user.id(), date);
-
-        return ResponseEntity.status(HttpStatus.OK).body(responses);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/calendar")
@@ -100,27 +63,6 @@ public class ChoreController {
             choreService.getCalendarMarkedDates(user.id(), startDate, endDate);
 
         return ResponseEntity.status(HttpStatus.OK).body(dates);
-    }
-
-    @DeleteMapping("/{choreId}")
-    public ResponseEntity<Void> deleteChore(
-        @AuthenticationPrincipal UserPrincipal user,
-        @PathVariable Long choreId) {
-
-        choreService.deleteChore(user.id(), choreId);
-
-        return ResponseEntity.noContent().build();
-    }
-
-    @DeleteMapping("/instances/{choreInstanceId}")
-    public ResponseEntity<Void> deleteChoreInstance(
-            @AuthenticationPrincipal UserPrincipal user,
-            @PathVariable Long choreInstanceId,
-            @RequestParam boolean applyToAfter) {
-
-        choreService.deleteChoreInstance(user.id(), choreInstanceId, applyToAfter);
-
-        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/completion-rate/{date}")
@@ -151,4 +93,3 @@ public class ChoreController {
         return ResponseEntity.status(HttpStatus.OK).body(chores);
     }
 }
-

--- a/src/main/java/com/zerobase/homemate/chore/controller/ChoreInstanceController.java
+++ b/src/main/java/com/zerobase/homemate/chore/controller/ChoreInstanceController.java
@@ -1,0 +1,79 @@
+package com.zerobase.homemate.chore.controller;
+
+import com.zerobase.homemate.auth.security.UserPrincipal;
+import com.zerobase.homemate.chore.dto.ChoreDto;
+import com.zerobase.homemate.chore.dto.ChoreDto.ApiResponse;
+import com.zerobase.homemate.chore.dto.ChoreInstanceDto;
+import com.zerobase.homemate.chore.service.ChoreService;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/chore-instances")
+@RequiredArgsConstructor
+public class ChoreInstanceController {
+
+    private final ChoreService choreService;
+
+    @GetMapping("/{choreInstanceId}")
+    public ResponseEntity<ChoreDto.Response> getChoreInstance(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long choreInstanceId) {
+
+        ChoreDto.Response response =
+                choreService.getChoreByInstanceId(user.id(), choreInstanceId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChoreInstanceDto.Response>> getChoreInstancesByDate(
+            @AuthenticationPrincipal UserPrincipal user,
+            @RequestParam LocalDate date) {
+
+        List<ChoreInstanceDto.Response> responses =
+                choreService.getChoreInstancesByDate(user.id(), date);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responses);
+    }
+
+    @PutMapping("/{choreInstanceId}")
+    public ResponseEntity<ApiResponse<ChoreDto.Response>> updateChoreInstance(
+        @AuthenticationPrincipal UserPrincipal user,
+        @PathVariable Long choreInstanceId,
+        @Valid @RequestBody ChoreDto.UpdateRequest request) {
+
+        ApiResponse<ChoreDto.Response> response = choreService.updateChores(user.id(),
+            choreInstanceId, request);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PatchMapping("/{choreInstanceId}/complete")
+    public ResponseEntity<ApiResponse<ChoreInstanceDto.Response>> completeChoreInstance(
+        @AuthenticationPrincipal UserPrincipal user,
+        @PathVariable Long choreInstanceId) {
+
+        ApiResponse<ChoreInstanceDto.Response> response =
+            choreService.completeChore(user.id(), choreInstanceId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @DeleteMapping("/{choreInstanceId}")
+    public ResponseEntity<Void> deleteChoreInstance(
+            @AuthenticationPrincipal UserPrincipal user,
+            @PathVariable Long choreInstanceId,
+            @RequestParam boolean applyToAfter) {
+
+        choreService.deleteChoreInstance(user.id(), choreInstanceId, applyToAfter);
+
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
<!-- PR 템플릿 틀입니다. 제가 다른 자료를 참고하여 임의로 작성한 부분이니 수정하셔서 사용하시면 될 것 같습니다! --> 
## 📝 계획
### 기존 상태
<!-- 코드 수정 전 기존 상태를 작성해주시면 됩니다. -->

- 집안일 관련 api가 하나의 컨트롤러에 모두 모여있음
- RESTful하지 않게 매핑된 URI
### 변경 후 상태
<!-- 코드 수정 후 상태를 작성해주시면 됩니다. -->

- `Chore`와 `ChoreInstance`로 컨트롤러 분리
- URI를 RESTful 하게 조정

## 💡PR에서 핵심적으로 변경된 사항
<!-- 이번 pr에서 핵심적으로 변경된 부분을 작성해주시면 됩니다. -->

- `Chore`와 `ChoreInstance`로 컨트롤러 분리 -> `/chores`와 `/chore-instances`로 매핑 변경
- 일부 비직관적(`/chore/{choreInstance}` 등)인 uri 수정

## 📢이외 추가 변경 부분 및 기타
<!-- 부가적으로 변경된 부분이나 추가적으로 생각하신 부분이 있다면 적어주세요. 
ex) 사용자 부분 수정하였는데 알람부분 충돌있는지 확인해야 할 것 같습니다. -->
- Chore 수정/삭제 api 추가를 위한 사전작업입니다.
## ✅ 테스트
<!-- 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 